### PR TITLE
Add support for hdim=256 in Flash Attention

### DIFF
--- a/opus_attn/Makefile
+++ b/opus_attn/Makefile
@@ -33,8 +33,10 @@ $(OUT): $(KERNEL_OBJS) $(HOST_OBJ)
 	$(HIPCC) $^ --offload-arch=$(ARCH) -fopenmp -o $@
 
 benchmark: $(OUT)
-	@echo "=== Causal ===" && $(OUT)
-	@echo "=== Non-causal ===" && $(OUT) --no-causal
+	@echo "=== hdim=128 Causal ===" && $(OUT) -d 128
+	@echo "=== hdim=128 Non-causal ===" && $(OUT) -d 128 --no-causal
+	@echo "=== hdim=256 Causal ===" && $(OUT) -d 256
+	@echo "=== hdim=256 Non-causal ===" && $(OUT) -d 256 --no-causal
 
 clean:
 	rm -rf $(BUILD)

--- a/opus_attn/README.md
+++ b/opus_attn/README.md
@@ -64,6 +64,7 @@ cd monolithic
 ./build/gqa_attn.exe --no-causal              # non-causal
 ./build/gqa_attn.exe -n=16384                 # causal, N=16384
 ./build/gqa_attn.exe --no-causal -n=16384     # non-causal, N=16384
+./build/gqa_attn.exe -d=256 --no-causal       # HesdDim=256, non-causal
 ```
 
 ### Command-line options
@@ -74,7 +75,7 @@ cd monolithic
 | `-h`, `--heads` | Number of query heads | 64 |
 | `--hkv` | Number of KV heads | 8 |
 | `-n`, `--seq` | Sequence length | 1024 |
-| `-d`, `--dim` | Head dimension (must be 128) | 128 |
+| `-d`, `--dim` | Head dimension (must be 128 or 256) | 128 |
 | `--causal` | Enable causal masking | (default) |
 | `--no-causal` | Disable causal masking | |
 | `-v`, `--verify` | CPU reference verification (0=off, 1=on) | 0 |
@@ -89,7 +90,7 @@ The kernel is parameterized via `opus_gqa_traits<Q_TILE, KV_TILE, D_TILE, NUM_WA
 |-----------|-------|-------------|
 | Q_TILE_SIZE | 32 | Query tile size per warp |
 | KV_TILE_SIZE | 64 | KV tile size in shared memory |
-| D_TILE_SIZE | 128 | Head dimension (fixed) |
+| D_TILE_SIZE | 128 | Head dimension (128 or 256) |
 | NUM_WARPS | 8 | Warps per workgroup (512 threads) |
 | CAUSAL | `true`/`false` | Causal masking (two separate kernel binaries) |
 | MFMA | 32x32x16 bf16 | Matrix multiply instruction |
@@ -131,3 +132,13 @@ B=16, H=64, H_KV=8, D=128, measured on MI355X:
 | 4096 | 1118 | 3.93 ms | 1227 | 7.17 ms |
 | 8192 | 1207 | 14.57 ms | 1265 | 27.80 ms |
 | 16384 | 1252 | 56.17 ms | 1275 | 110.37 ms |
+
+B=16, H=64, H_KV=8, D=256, measured on MI355X:
+
+| N | Causal TFlops | Causal Time | Non-causal TFlops | Non-causal Time |
+|---:|---:|---:|---:|---:|
+| 1024 | 550 | 0.99 ms | 701 | 1.569 ms |
+| 2048 | 714 | 3.08 ms | 809 | 5.425 ms |
+| 4096 | 819 | 10.73 ms | 861 | 20.41 ms |
+| 8192 | 878 | 40.05 ms | 889 | 79.07 ms |
+| 16384 | 915 | 153.64 ms | 902 | 311.97 ms |

--- a/opus_attn/gqa_gfx950_host.cc
+++ b/opus_attn/gqa_gfx950_host.cc
@@ -76,8 +76,8 @@ void benchmark_gqa_kernel(const opus_gqa_kargs& kargs, dim3 grid, dim3 block,
                        / (Traits::CAUSAL ? 2.0 : 1.0);
     const double tflops = flops / (avg_time * 1e-3) / 1e12;
 
-    printf("GQA %s Kernel Performance: avg_time=%.3f ms, %.2f TFlops\n",
-           Traits::CAUSAL ? "Causal" : "Non-causal", avg_time, tflops);
+    printf("GQA %s (hdim=%d) Kernel Performance: avg_time=%.3f ms, %.2f TFlops\n",
+           Traits::CAUSAL ? "Causal" : "Non-causal", Traits::D_TILE_SIZE, avg_time, tflops);
 }
 
 // Validate GQA GPU results against CPU reference
@@ -211,7 +211,7 @@ int main(int argc, char** argv) {
     int H    = 64;    // query heads
     int H_KV = 8;     // key/value heads
     int N    = 1024;  // sequence length
-    int D    = 128;   // head dimension
+    int D    = 128;   // head dimension (can be 128 or 256)
 
     // Parse command line arguments. Supports: -n 16384, -n=16384, --seq=16384
     bool causal = true;
@@ -342,11 +342,16 @@ int main(int argc, char** argv) {
         return 0;
     };
 
-    int rc;
-    if (causal)
+    int rc = 0;
+    if (D == 128 && causal) {
         rc = run(opus_gqa_traits<32, 64, 128, 8, true>{});
-    else
+    } else if (D == 128 && !causal) {
         rc = run(opus_gqa_traits<32, 64, 128, 8, false>{});
+    } else if (D == 256 && causal) {
+        rc = run(opus_gqa_traits<32, 64, 256, 4, true>{});
+    } else if (D == 256 && !causal) {
+        rc = run(opus_gqa_traits<32, 64, 256, 4, false>{});
+    }
     if (rc) return rc;
 
     // Cleanup

--- a/opus_attn/gqa_gfx950_kernel_causal.cc
+++ b/opus_attn/gqa_gfx950_kernel_causal.cc
@@ -6,7 +6,9 @@
 #ifndef __HIP_DEVICE_COMPILE__
 template<typename Traits> __global__ void gqa_kernel(opus_gqa_kargs kargs) {}
 template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 128, 8, true>>(opus_gqa_kargs);
+template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 256, 4, true>>(opus_gqa_kargs);
 #else
 #include "gqa_gfx950_kernel_template.hpp"
 template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 128, 8, true>>(opus_gqa_kargs);
+template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 256, 4, true>>(opus_gqa_kargs);
 #endif

--- a/opus_attn/gqa_gfx950_kernel_noncausal.cc
+++ b/opus_attn/gqa_gfx950_kernel_noncausal.cc
@@ -6,7 +6,9 @@
 #ifndef __HIP_DEVICE_COMPILE__
 template<typename Traits> __global__ void gqa_kernel(opus_gqa_kargs kargs) {}
 template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 128, 8, false>>(opus_gqa_kargs);
+template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 256, 4, false>>(opus_gqa_kargs);
 #else
 #include "gqa_gfx950_kernel_template.hpp"
 template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 128, 8, false>>(opus_gqa_kargs);
+template __global__ void gqa_kernel<opus_gqa_traits<32, 64, 256, 4, false>>(opus_gqa_kargs);
 #endif

--- a/opus_attn/gqa_gfx950_kernel_template.hpp
+++ b/opus_attn/gqa_gfx950_kernel_template.hpp
@@ -7,6 +7,14 @@
 #include <bit>
 #include <cstdint>
 
+// HDIM-dependent configuration - select based on D_TILE_SIZE at compile time
+template<int D_TILE_SIZE>
+struct kernel_config {
+    static constexpr int OCCUPANCY_HINT = (D_TILE_SIZE == 128) ? 2 : 1;
+    static constexpr int SCHED_EXP_PAIRS = (D_TILE_SIZE == 128) ? 6 : 12;
+    static constexpr int SCHED_VALU_PAIRS = (D_TILE_SIZE == 128) ? 10 : 20;
+};
+
 using opus::operator""_I;
 
 constexpr int MFMA_MASK = 0x08;
@@ -293,9 +301,13 @@ __device__ inline void attn_mask_causal_tile(V& v_s, int q_start_pos, int kv_til
 
 // ─── GQA kernel: template on traits; K/V in shared, Q in registers, Flash Attention online softmax ───
 template<class Traits>
-__global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kargs kargs) {
+__global__ __launch_bounds__(Traits::BLOCK_SIZE, kernel_config<Traits::D_TILE_SIZE>::OCCUPANCY_HINT) void gqa_kernel(opus_gqa_kargs kargs) {
     using namespace opus;
     using T = opus::remove_cvref_t<Traits>;
+    // HDIM-dependent parameters
+    using KConfig = kernel_config<T::D_TILE_SIZE>;
+    constexpr int SCHED_EXP_PAIRS = KConfig::SCHED_EXP_PAIRS;
+    constexpr int SCHED_VALU_PAIRS = KConfig::SCHED_VALU_PAIRS;
     using D_ATTN = typename T::D_ATTN;
     using D_ACC = typename T::D_ACC;
 
@@ -311,8 +323,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     const int h_kv = h / group_size;
     const int q_block_size = T::NUM_WARPS * T::Q_TILE_SIZE;
     const int q_block_start = q_block_idx * q_block_size;
-    const int qo_gmem_offset = b * kargs.stride_q_b + q_block_start * kargs.stride_q_n + h * kargs.stride_q_h;
-    const int kv_gmem_offset = b * kargs.stride_kv_b + h_kv * kargs.stride_kv_h;
+    const int64_t qo_gmem_offset = (int64_t)b * kargs.stride_q_b + (int64_t)q_block_start * kargs.stride_q_n + h * kargs.stride_q_h;
+    const int64_t kv_gmem_offset = (int64_t)b * kargs.stride_kv_b + h_kv * kargs.stride_kv_h;
 
     // Global memory tensors
     auto g_q = make_gmem(reinterpret_cast<const D_ATTN*>(kargs.ptr_q) + qo_gmem_offset);
@@ -450,8 +462,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
         l_row += attn_sum<T>(v_s[0]);
         v_p = opus::cast<D_ATTN>(v_s[0]);
         asm volatile("" : "+v"(v_p) ::);
-        sched_barrier_exp_pairs<6, 3, 1>();
-        sched_barrier_pairs<10, 5, 1>();
+        sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 1>();
+        sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 1>();
         __builtin_amdgcn_sched_barrier(0);
         __builtin_amdgcn_s_barrier();
         __builtin_amdgcn_sched_barrier(0);
@@ -487,7 +499,7 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
         asm volatile("" : "+v"(v_s[1]) ::);
         attn_exp2_slice<T, 0, s_half_len>(v_s[1]);
         sched_barrier_pairs<6, 5, 2>();
-        sched_barrier_exp_pairs<6, 3, 2>();
+        sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 2>();
         __builtin_amdgcn_s_setprio(0);
         __builtin_amdgcn_sched_barrier(0);
         __builtin_amdgcn_s_barrier();
@@ -508,8 +520,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
         l_row += attn_sum<T>(v_s[1]);
         v_p = opus::cast<D_ATTN>(v_s[1]);
         asm volatile("" : "+v"(v_p) ::);
-        sched_barrier_exp_pairs<6, 3, 3>();
-        sched_barrier_pairs<10, 5, 3>();
+        sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 3>();
+        sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 3>();
         __builtin_amdgcn_sched_barrier(0);
         __builtin_amdgcn_s_barrier();
         __builtin_amdgcn_sched_barrier(0);
@@ -551,7 +563,7 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
         asm volatile("" : "+v"(v_s[0]) ::);
         attn_exp2_slice<T, 0, s_half_len>(v_s[0]);
         sched_barrier_pairs<6, 5, 4>();
-        sched_barrier_exp_pairs<6, 3, 4>();
+        sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 4>();
         __builtin_amdgcn_s_setprio(0);
         __builtin_amdgcn_sched_barrier(0);
         __builtin_amdgcn_s_barrier();
@@ -574,8 +586,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     l_row += attn_sum<T>(v_s[0]);
     v_p = opus::cast<D_ATTN>(v_s[0]);
     asm volatile("" : "+v"(v_p) ::);
-    sched_barrier_exp_pairs<6, 3, 5>();
-    sched_barrier_pairs<10, 5, 5>();
+    sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 5>();
+    sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 5>();
     __builtin_amdgcn_sched_barrier(0);
     __builtin_amdgcn_s_barrier();
     __builtin_amdgcn_sched_barrier(0);
@@ -604,8 +616,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     attn_sub_row<T>(v_s[1], row_max);
     asm volatile("" : "+v"(v_s[1]) ::);
     attn_exp2_slice<T, 0, s_half_len>(v_s[1]);
-    sched_barrier_pairs<10, 5, 6>();
-    sched_barrier_exp_pairs<6, 3, 6>();
+    sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 6>();
+    sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 6>();
     __builtin_amdgcn_sched_barrier(0);
     scale_output_tile<T>(v_o, rescale_m);
     auto* v_o_pin = reinterpret_cast<vector_t<fp32_t, 16>*>(&v_o);
@@ -631,8 +643,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     l_row += attn_sum<T>(v_s[1]);
     v_p = opus::cast<D_ATTN>(v_s[1]);
     asm volatile("" : "+v"(v_p) ::);
-    sched_barrier_exp_pairs<6, 3, 7>();
-    sched_barrier_pairs<10, 5, 7>();
+    sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 7>();
+    sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 7>();
     __builtin_amdgcn_sched_barrier(0);
     __builtin_amdgcn_s_barrier();
     __builtin_amdgcn_sched_barrier(0);
@@ -660,8 +672,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     attn_sub_row<T>(v_s[0], row_max);
     asm volatile("" : "+v"(v_s[0]) ::);
     attn_exp2_slice<T, 0, s_half_len>(v_s[0]);
-    sched_barrier_pairs<10, 5, 8>();
-    sched_barrier_exp_pairs<6, 3, 8>();
+    sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 8>();
+    sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 8>();
     __builtin_amdgcn_sched_barrier(0);
     scale_output_tile<T>(v_o, rescale_m);
     asm volatile("" : "+v"(v_o_pin[0]), "+v"(v_o_pin[1]), "+v"(v_o_pin[2]), "+v"(v_o_pin[3]) ::);
@@ -686,8 +698,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     l_row += attn_sum<T>(v_s[0]);
     v_p = opus::cast<D_ATTN>(v_s[0]);
     asm volatile("" : "+v"(v_p) ::);
-    sched_barrier_exp_pairs<6, 3, 9>();
-    sched_barrier_pairs<10, 5, 9>();
+    sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 9>();
+    sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 9>();
     __builtin_amdgcn_sched_barrier(0);
     __builtin_amdgcn_s_barrier();
     __builtin_amdgcn_sched_barrier(0);
@@ -714,8 +726,8 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     attn_sub_row<T>(v_s[1], row_max);
     asm volatile("" : "+v"(v_s[1]) ::);
     attn_exp2_slice<T, 0, s_half_len>(v_s[1]);
-    sched_barrier_pairs<10, 5, 10>();
-    sched_barrier_exp_pairs<6, 3, 10>();
+    sched_barrier_pairs<SCHED_VALU_PAIRS, 5, 10>();
+    sched_barrier_exp_pairs<SCHED_EXP_PAIRS, 3, 10>();
     __builtin_amdgcn_sched_barrier(0);
 
     attn_exp2_slice<T, s_half_len, s_half_len>(v_s[1]);

--- a/opus_attn/rebuild.sh
+++ b/opus_attn/rebuild.sh
@@ -22,6 +22,7 @@ echo "Output: $TOP/build/gqa_attn.exe"
 echo ""
 
 # Run benchmark
+echo "=== Head Dim 128 ==="
 echo "=== Causal ==="
 ./build/gqa_attn.exe --causal
 echo ""
@@ -33,3 +34,15 @@ echo "=== Non-causal ==="
 echo ""
 echo "=== Non-causal N=16384 ==="
 ./build/gqa_attn.exe --no-causal -n 16384
+echo "=== Head Dim 256 ==="
+echo "=== Causal ==="
+./build/gqa_attn.exe --causal -d 256
+echo ""
+echo "=== Causal N=16384 ==="
+./build/gqa_attn.exe --causal -n 16384 -d 256
+echo ""
+echo "=== Non-causal ==="
+./build/gqa_attn.exe --no-causal -d 256
+echo ""
+echo "=== Non-causal N=16384 ==="
+./build/gqa_attn.exe --no-causal -n 16384 -d 256


### PR DESCRIPTION
This commit extends the GQA Flash Attention kernel to support head
dimension 256, in addition to the existing hdim=128 support.

Changes:
  - Add kernel_config template for hdim-dependent parameters
    (occupancy, scheduling barrier pairs)
  - Instantiate new kernel variants: opus_gqa_traits<32,64,256,4,*>
    (NUM_WARPS reduced from 8 to 4 for memory constraints)
  - Update host code to accept -d/--dim 256 and dispatch to
    appropriate kernel
  - Fix gmem_offset overflow by using int64_t instead of int
  - Update benchmark targets and documentation with hdim=256
    performance data

Testing:
  - Verified correctness with CPU reference (-v 1)
  - Benchmarked on MI355X for N=1024/2048/4096/8192/16384
  - Performance: ~550-915 TFlops (causal), ~701-902 TFlops (non-causal)

Tested-by: make benchmark, ./rebuild.sh
