### PR TITLE
opus_attn: conditional epilogue rescale for causal attention

### DIFF
--- a/opus_attn/gqa_gfx950_kernel_template.hpp
+++ b/opus_attn/gqa_gfx950_kernel_template.hpp
@@ -599,9 +599,15 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     __builtin_amdgcn_s_setprio(1);
     v_o = mma1(v_p, v_v, v_o);
     D_ACC row_max = attn_row_max<T>(v_s[1]);
-    rescale_m = __builtin_amdgcn_exp2f(m_row - row_max);
-    m_row = row_max;
-    attn_sub_row<T>(v_s[1], row_max);
+    if constexpr (T::CAUSAL) {
+        bool need_rescale = (row_max > m_row);
+        rescale_m = need_rescale ? __builtin_amdgcn_exp2f(m_row - row_max) : D_ACC(1.0f);
+        m_row = need_rescale ? row_max : m_row;
+    } else {
+        rescale_m = __builtin_amdgcn_exp2f(m_row - row_max);
+        m_row = row_max;
+    }
+    attn_sub_row<T>(v_s[1], m_row);
     asm volatile("" : "+v"(v_s[1]) ::);
     attn_exp2_slice<T, 0, s_half_len>(v_s[1]);
     sched_barrier_pairs<10, 5, 6>();
@@ -655,9 +661,15 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     __builtin_amdgcn_s_setprio(1);
     v_o = mma1(v_p, v_v, v_o);
     row_max = attn_row_max<T>(v_s[0]);
-    rescale_m = __builtin_amdgcn_exp2f(m_row - row_max);
-    m_row = row_max;
-    attn_sub_row<T>(v_s[0], row_max);
+    if constexpr (T::CAUSAL) {
+        bool need_rescale = (row_max > m_row);
+        rescale_m = need_rescale ? __builtin_amdgcn_exp2f(m_row - row_max) : D_ACC(1.0f);
+        m_row = need_rescale ? row_max : m_row;
+    } else {
+        rescale_m = __builtin_amdgcn_exp2f(m_row - row_max);
+        m_row = row_max;
+    }
+    attn_sub_row<T>(v_s[0], m_row);
     asm volatile("" : "+v"(v_s[0]) ::);
     attn_exp2_slice<T, 0, s_half_len>(v_s[0]);
     sched_barrier_pairs<10, 5, 8>();
@@ -709,9 +721,15 @@ __global__ __launch_bounds__(Traits::BLOCK_SIZE, 2) void gqa_kernel(opus_gqa_kar
     // Cluster 10:
     v_o = mma1(v_p, v_v, v_o);
     row_max = attn_row_max<T>(v_s[1]);
-    rescale_m = __builtin_amdgcn_exp2f(m_row - row_max);
-    m_row = row_max;
-    attn_sub_row<T>(v_s[1], row_max);
+    if constexpr (T::CAUSAL) {
+        bool need_rescale = (row_max > m_row);
+        rescale_m = need_rescale ? __builtin_amdgcn_exp2f(m_row - row_max) : D_ACC(1.0f);
+        m_row = need_rescale ? row_max : m_row;
+    } else {
+        rescale_m = __builtin_amdgcn_exp2f(m_row - row_max);
+        m_row = row_max;
+    }
+    attn_sub_row<T>(v_s[1], m_row);
     asm volatile("" : "+v"(v_s[1]) ::);
     attn_exp2_slice<T, 0, s_half_len>(v_s[1]);
     sched_barrier_pairs<10, 5, 10>();


### PR DESCRIPTION
## Summary

- Fix causal correctness bug in epilogue softmax rescale (3 sites: Cluster 2, 6, 10)
- The unconditional `exp2(m_row - row_max)` and `attn_sub_row(v_s, row_max)` pattern has two issues for causal attention:
  1. **Fully-masked tiles:** `row_max = -inf` causes `exp2(+inf) = +inf` → NaN output (latent: `max_num_tiles` currently skips these, but fragile)
  2. **Partially-masked tiles:** `attn_sub_row` uses tile-local max instead of running max `m_row`, inflating tile probabilities when `row_max < m_row`
- Fix: conditional rescale for causal mode (`if constexpr (T::CAUSAL)`), use `m_row` for `attn_sub_row`
- Noncausal path unchanged

## Why existing validation misses this

The `-v 1` flag only checks 8 rows per head (rows 0-7), all within KV tile 0 — never reaching affected rows 64+. The element-wise threshold (5e-2) is also too loose. A cosine similarity check (0.999) on all rows catches the bug.

## Test plan

- [x] Build: `OPUS_INCLUDE_DIR=<path> make -j`
- [x] Run causal validation: `./build/gqa_attn.exe --causal -n 1024 -v 1`
- [x] Run noncausal validation: `./build/gqa_attn.exe --no-causal -n 1024 -v 1`
- [x] Verify noncausal assembly unchanged (only causal path modified via `if constexpr`)