### PR TITLE
opus_attn_gfx1201: HIP FA-fwd beyond #24 (v139, 92.8 TFLOPS) [lane_A]

### DIFF
--- a/opus_attn_gfx1201/Makefile
+++ b/opus_attn_gfx1201/Makefile
@@ -51,7 +51,8 @@ KERNELS  := attn_gfx1201_kernel_v0.cc \
     attn_gfx1201_kernel_v43.cc \
     attn_gfx1201_kernel_v44.cc \
     attn_gfx1201_kernel_v45.cc \
-    attn_gfx1201_kernel_v48.cc
+    attn_gfx1201_kernel_v48.cc \
+    attn_gfx1201_kernel_v100.cc
 KERN_OBJ := $(patsubst %.cc,$(BUILD)/%.o,$(KERNELS))
 HOST_OBJ := $(BUILD)/attn_gfx1201_host.o
 
@@ -254,6 +255,9 @@ $(BUILD)/attn_gfx1201_kernel_v45.o: attn_gfx1201_kernel_v45.cc attn_gfx1201_kern
 	$(HIPCC) -x hip $(CXXFLAGS) -c $< -o $@
 
 $(BUILD)/attn_gfx1201_kernel_v48.o: attn_gfx1201_kernel_v48.cc attn_gfx1201_kernel_v48_template.hpp attn_common.h | $(BUILD)
+	$(HIPCC) -x hip $(CXXFLAGS) -c $< -o $@
+
+$(BUILD)/attn_gfx1201_kernel_v100.o: attn_gfx1201_kernel_v100.cc attn_gfx1201_kernel_v100_template.hpp attn_common.h | $(BUILD)
 	$(HIPCC) -x hip $(CXXFLAGS) -c $< -o $@
 
 # v49: hand-scheduled ASM kernel, loaded as HSACO at runtime

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -68,6 +68,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v100(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v101(opus_attn_kargs); // v101
 template<class T> __global__ void opus_attn_gfx1201_kernel_v102(opus_attn_kargs); // v102
 template<class T> __global__ void opus_attn_gfx1201_kernel_v103(opus_attn_kargs); // v103
+template<class T> __global__ void opus_attn_gfx1201_kernel_v104(opus_attn_kargs); // v104
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -152,6 +153,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 101: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v101<opus_attn_traits<128, 32, 128>>); break;
         case 102: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v102<opus_attn_traits<128, 32, 128>>); break;
         case 103: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v103<opus_attn_traits<128, 32, 128>>); break;
+        case 104: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v104<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -242,7 +244,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -90,6 +90,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v122(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v123(opus_attn_kargs); // v123
 template<class T> __global__ void opus_attn_gfx1201_kernel_v124(opus_attn_kargs); // v124
 template<class T> __global__ void opus_attn_gfx1201_kernel_v125(opus_attn_kargs); // v125
+template<class T> __global__ void opus_attn_gfx1201_kernel_v126(opus_attn_kargs); // v126
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -196,6 +197,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 123: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v123<opus_attn_traits<128, 32, 128>>); break;
         case 124: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v124<opus_attn_traits<128, 32, 128>>); break;
         case 125: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v125<opus_attn_traits<128, 32, 128>>); break;
+        case 126: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v126<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -286,7 +288,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -83,6 +83,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v115(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v116(opus_attn_kargs); // v116
 template<class T> __global__ void opus_attn_gfx1201_kernel_v117(opus_attn_kargs); // v117
 template<class T> __global__ void opus_attn_gfx1201_kernel_v118(opus_attn_kargs); // v118
+template<class T> __global__ void opus_attn_gfx1201_kernel_v119(opus_attn_kargs); // v119
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -182,6 +183,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 116: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v116<opus_attn_traits<128, 32, 128>>); break;
         case 117: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v117<opus_attn_traits<128, 32, 128>>); break;
         case 118: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v118<opus_attn_traits<128, 32, 128>>); break;
+        case 119: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v119<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -272,7 +274,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -88,6 +88,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v120(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v121(opus_attn_kargs); // v121
 template<class T> __global__ void opus_attn_gfx1201_kernel_v122(opus_attn_kargs); // v122
 template<class T> __global__ void opus_attn_gfx1201_kernel_v123(opus_attn_kargs); // v123
+template<class T> __global__ void opus_attn_gfx1201_kernel_v124(opus_attn_kargs); // v124
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -192,6 +193,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 121: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v121<opus_attn_traits<128, 32, 128>>); break;
         case 122: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v122<opus_attn_traits<128, 32, 128>>); break;
         case 123: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v123<opus_attn_traits<128, 32, 128>>); break;
+        case 124: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v124<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -282,7 +284,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -93,6 +93,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v125(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v126(opus_attn_kargs); // v126
 template<class T> __global__ void opus_attn_gfx1201_kernel_v127(opus_attn_kargs); // v127
 template<class T> __global__ void opus_attn_gfx1201_kernel_v128(opus_attn_kargs); // v128
+template<class T> __global__ void opus_attn_gfx1201_kernel_v129(opus_attn_kargs); // v129
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -202,6 +203,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 126: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v126<opus_attn_traits<128, 32, 128>>); break;
         case 127: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v127<opus_attn_traits<128, 32, 128>>); break;
         case 128: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v128<opus_attn_traits<128, 32, 128>>); break;
+        case 129: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v129<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -292,7 +294,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -72,6 +72,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v104(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v105(opus_attn_kargs); // v105
 template<class T> __global__ void opus_attn_gfx1201_kernel_v106(opus_attn_kargs); // v106
 template<class T> __global__ void opus_attn_gfx1201_kernel_v107(opus_attn_kargs); // v107
+template<class T> __global__ void opus_attn_gfx1201_kernel_v108(opus_attn_kargs); // v108
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -160,6 +161,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 105: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v105<opus_attn_traits<128, 32, 128>>); break;
         case 106: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v106<opus_attn_traits<128, 32, 128>>); break;
         case 107: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v107<opus_attn_traits<128, 32, 128>>); break;
+        case 108: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v108<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -250,7 +252,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -92,6 +92,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v124(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v125(opus_attn_kargs); // v125
 template<class T> __global__ void opus_attn_gfx1201_kernel_v126(opus_attn_kargs); // v126
 template<class T> __global__ void opus_attn_gfx1201_kernel_v127(opus_attn_kargs); // v127
+template<class T> __global__ void opus_attn_gfx1201_kernel_v128(opus_attn_kargs); // v128
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -200,6 +201,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 125: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v125<opus_attn_traits<128, 32, 128>>); break;
         case 126: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v126<opus_attn_traits<128, 32, 128>>); break;
         case 127: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v127<opus_attn_traits<128, 32, 128>>); break;
+        case 128: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v128<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -290,7 +292,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -96,6 +96,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v128(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v129(opus_attn_kargs); // v129
 template<class T> __global__ void opus_attn_gfx1201_kernel_v130(opus_attn_kargs); // v130
 template<class T> __global__ void opus_attn_gfx1201_kernel_v131(opus_attn_kargs); // v131
+template<class T> __global__ void opus_attn_gfx1201_kernel_v132(opus_attn_kargs); // v132
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -208,6 +209,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 129: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v129<opus_attn_traits<128, 32, 128>>); break;
         case 130: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v130<opus_attn_traits<128, 32, 128>>); break;
         case 131: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v131<opus_attn_traits<128, 32, 128>>); break;
+        case 132: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v132<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -298,7 +300,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -66,6 +66,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v45(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v48(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v100(opus_attn_kargs); // v100
 template<class T> __global__ void opus_attn_gfx1201_kernel_v101(opus_attn_kargs); // v101
+template<class T> __global__ void opus_attn_gfx1201_kernel_v102(opus_attn_kargs); // v102
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -148,6 +149,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 49: launch_v49_asm(k); break;
         case 100: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v100<opus_attn_traits<128, 32, 128>>); break;
         case 101: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v101<opus_attn_traits<128, 32, 128>>); break;
+        case 102: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v102<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -238,7 +240,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -103,6 +103,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v135(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v136(opus_attn_kargs); // v136
 template<class T> __global__ void opus_attn_gfx1201_kernel_v137(opus_attn_kargs); // v137
 template<class T> __global__ void opus_attn_gfx1201_kernel_v138(opus_attn_kargs); // v138
+template<class T> __global__ void opus_attn_gfx1201_kernel_v139(opus_attn_kargs); // v139
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -222,6 +223,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 136: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v136<opus_attn_traits<128, 32, 128>>); break;
         case 137: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v137<opus_attn_traits<128, 32, 128>>); break;
         case 138: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v138<opus_attn_traits<128, 32, 128>>); break;
+        case 139: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v139<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -312,7 +314,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135 || version == 136 || version == 137 || version == 138) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135 || version == 136 || version == 137 || version == 138 || version == 139) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -91,6 +91,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v123(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v124(opus_attn_kargs); // v124
 template<class T> __global__ void opus_attn_gfx1201_kernel_v125(opus_attn_kargs); // v125
 template<class T> __global__ void opus_attn_gfx1201_kernel_v126(opus_attn_kargs); // v126
+template<class T> __global__ void opus_attn_gfx1201_kernel_v127(opus_attn_kargs); // v127
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -198,6 +199,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 124: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v124<opus_attn_traits<128, 32, 128>>); break;
         case 125: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v125<opus_attn_traits<128, 32, 128>>); break;
         case 126: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v126<opus_attn_traits<128, 32, 128>>); break;
+        case 127: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v127<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -288,7 +290,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -84,6 +84,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v116(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v117(opus_attn_kargs); // v117
 template<class T> __global__ void opus_attn_gfx1201_kernel_v118(opus_attn_kargs); // v118
 template<class T> __global__ void opus_attn_gfx1201_kernel_v119(opus_attn_kargs); // v119
+template<class T> __global__ void opus_attn_gfx1201_kernel_v120(opus_attn_kargs); // v120
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -184,6 +185,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 117: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v117<opus_attn_traits<128, 32, 128>>); break;
         case 118: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v118<opus_attn_traits<128, 32, 128>>); break;
         case 119: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v119<opus_attn_traits<128, 32, 128>>); break;
+        case 120: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v120<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -274,7 +276,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -81,6 +81,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v113(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v114(opus_attn_kargs); // v114
 template<class T> __global__ void opus_attn_gfx1201_kernel_v115(opus_attn_kargs); // v115
 template<class T> __global__ void opus_attn_gfx1201_kernel_v116(opus_attn_kargs); // v116
+template<class T> __global__ void opus_attn_gfx1201_kernel_v117(opus_attn_kargs); // v117
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -178,6 +179,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 114: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v114<opus_attn_traits<128, 32, 128>>); break;
         case 115: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v115<opus_attn_traits<128, 32, 128>>); break;
         case 116: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v116<opus_attn_traits<128, 32, 128>>); break;
+        case 117: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v117<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -268,7 +270,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -64,6 +64,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v43(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v44(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v45(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v48(opus_attn_kargs);
+template<class T> __global__ void opus_attn_gfx1201_kernel_v100(opus_attn_kargs); // v100
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -144,6 +145,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 45: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v45<opus_attn_traits<128, 32, 128>>); break;
         case 48: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v48<opus_attn_traits<128, 32, 128>>); break;
         case 49: launch_v49_asm(k); break;
+        case 100: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v100<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -234,7 +236,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -79,6 +79,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v111(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v112(opus_attn_kargs); // v112
 template<class T> __global__ void opus_attn_gfx1201_kernel_v113(opus_attn_kargs); // v113
 template<class T> __global__ void opus_attn_gfx1201_kernel_v114(opus_attn_kargs); // v114
+template<class T> __global__ void opus_attn_gfx1201_kernel_v115(opus_attn_kargs); // v115
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -174,6 +175,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 112: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v112<opus_attn_traits<128, 32, 128>>); break;
         case 113: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v113<opus_attn_traits<128, 32, 128>>); break;
         case 114: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v114<opus_attn_traits<128, 32, 128>>); break;
+        case 115: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v115<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -264,7 +266,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -95,6 +95,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v127(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v128(opus_attn_kargs); // v128
 template<class T> __global__ void opus_attn_gfx1201_kernel_v129(opus_attn_kargs); // v129
 template<class T> __global__ void opus_attn_gfx1201_kernel_v130(opus_attn_kargs); // v130
+template<class T> __global__ void opus_attn_gfx1201_kernel_v131(opus_attn_kargs); // v131
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -206,6 +207,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 128: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v128<opus_attn_traits<128, 32, 128>>); break;
         case 129: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v129<opus_attn_traits<128, 32, 128>>); break;
         case 130: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v130<opus_attn_traits<128, 32, 128>>); break;
+        case 131: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v131<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -296,7 +298,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -67,6 +67,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v48(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v100(opus_attn_kargs); // v100
 template<class T> __global__ void opus_attn_gfx1201_kernel_v101(opus_attn_kargs); // v101
 template<class T> __global__ void opus_attn_gfx1201_kernel_v102(opus_attn_kargs); // v102
+template<class T> __global__ void opus_attn_gfx1201_kernel_v103(opus_attn_kargs); // v103
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -150,6 +151,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 100: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v100<opus_attn_traits<128, 32, 128>>); break;
         case 101: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v101<opus_attn_traits<128, 32, 128>>); break;
         case 102: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v102<opus_attn_traits<128, 32, 128>>); break;
+        case 103: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v103<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -240,7 +242,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -78,6 +78,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v110(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v111(opus_attn_kargs); // v111
 template<class T> __global__ void opus_attn_gfx1201_kernel_v112(opus_attn_kargs); // v112
 template<class T> __global__ void opus_attn_gfx1201_kernel_v113(opus_attn_kargs); // v113
+template<class T> __global__ void opus_attn_gfx1201_kernel_v114(opus_attn_kargs); // v114
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -172,6 +173,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 111: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v111<opus_attn_traits<128, 32, 128>>); break;
         case 112: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v112<opus_attn_traits<128, 32, 128>>); break;
         case 113: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v113<opus_attn_traits<128, 32, 128>>); break;
+        case 114: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v114<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -262,7 +264,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -80,6 +80,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v112(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v113(opus_attn_kargs); // v113
 template<class T> __global__ void opus_attn_gfx1201_kernel_v114(opus_attn_kargs); // v114
 template<class T> __global__ void opus_attn_gfx1201_kernel_v115(opus_attn_kargs); // v115
+template<class T> __global__ void opus_attn_gfx1201_kernel_v116(opus_attn_kargs); // v116
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -176,6 +177,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 113: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v113<opus_attn_traits<128, 32, 128>>); break;
         case 114: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v114<opus_attn_traits<128, 32, 128>>); break;
         case 115: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v115<opus_attn_traits<128, 32, 128>>); break;
+        case 116: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v116<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -266,7 +268,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -85,6 +85,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v117(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v118(opus_attn_kargs); // v118
 template<class T> __global__ void opus_attn_gfx1201_kernel_v119(opus_attn_kargs); // v119
 template<class T> __global__ void opus_attn_gfx1201_kernel_v120(opus_attn_kargs); // v120
+template<class T> __global__ void opus_attn_gfx1201_kernel_v121(opus_attn_kargs); // v121
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -186,6 +187,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 118: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v118<opus_attn_traits<128, 32, 128>>); break;
         case 119: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v119<opus_attn_traits<128, 32, 128>>); break;
         case 120: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v120<opus_attn_traits<128, 32, 128>>); break;
+        case 121: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v121<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -276,7 +278,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -76,6 +76,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v108(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v109(opus_attn_kargs); // v109
 template<class T> __global__ void opus_attn_gfx1201_kernel_v110(opus_attn_kargs); // v110
 template<class T> __global__ void opus_attn_gfx1201_kernel_v111(opus_attn_kargs); // v111
+template<class T> __global__ void opus_attn_gfx1201_kernel_v112(opus_attn_kargs); // v112
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -168,6 +169,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 109: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v109<opus_attn_traits<128, 32, 128>>); break;
         case 110: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v110<opus_attn_traits<128, 32, 128>>); break;
         case 111: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v111<opus_attn_traits<128, 32, 128>>); break;
+        case 112: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v112<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -86,6 +86,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v118(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v119(opus_attn_kargs); // v119
 template<class T> __global__ void opus_attn_gfx1201_kernel_v120(opus_attn_kargs); // v120
 template<class T> __global__ void opus_attn_gfx1201_kernel_v121(opus_attn_kargs); // v121
+template<class T> __global__ void opus_attn_gfx1201_kernel_v122(opus_attn_kargs); // v122
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -188,6 +189,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 119: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v119<opus_attn_traits<128, 32, 128>>); break;
         case 120: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v120<opus_attn_traits<128, 32, 128>>); break;
         case 121: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v121<opus_attn_traits<128, 32, 128>>); break;
+        case 122: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v122<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -278,7 +280,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -89,6 +89,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v121(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v122(opus_attn_kargs); // v122
 template<class T> __global__ void opus_attn_gfx1201_kernel_v123(opus_attn_kargs); // v123
 template<class T> __global__ void opus_attn_gfx1201_kernel_v124(opus_attn_kargs); // v124
+template<class T> __global__ void opus_attn_gfx1201_kernel_v125(opus_attn_kargs); // v125
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -194,6 +195,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 122: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v122<opus_attn_traits<128, 32, 128>>); break;
         case 123: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v123<opus_attn_traits<128, 32, 128>>); break;
         case 124: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v124<opus_attn_traits<128, 32, 128>>); break;
+        case 125: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v125<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -284,7 +286,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -70,6 +70,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v102(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v103(opus_attn_kargs); // v103
 template<class T> __global__ void opus_attn_gfx1201_kernel_v104(opus_attn_kargs); // v104
 template<class T> __global__ void opus_attn_gfx1201_kernel_v105(opus_attn_kargs); // v105
+template<class T> __global__ void opus_attn_gfx1201_kernel_v106(opus_attn_kargs); // v106
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -156,6 +157,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 103: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v103<opus_attn_traits<128, 32, 128>>); break;
         case 104: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v104<opus_attn_traits<128, 32, 128>>); break;
         case 105: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v105<opus_attn_traits<128, 32, 128>>); break;
+        case 106: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v106<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -246,7 +248,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -87,6 +87,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v119(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v120(opus_attn_kargs); // v120
 template<class T> __global__ void opus_attn_gfx1201_kernel_v121(opus_attn_kargs); // v121
 template<class T> __global__ void opus_attn_gfx1201_kernel_v122(opus_attn_kargs); // v122
+template<class T> __global__ void opus_attn_gfx1201_kernel_v123(opus_attn_kargs); // v123
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -190,6 +191,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 120: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v120<opus_attn_traits<128, 32, 128>>); break;
         case 121: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v121<opus_attn_traits<128, 32, 128>>); break;
         case 122: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v122<opus_attn_traits<128, 32, 128>>); break;
+        case 123: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v123<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -280,7 +282,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -100,6 +100,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v132(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v133(opus_attn_kargs); // v133
 template<class T> __global__ void opus_attn_gfx1201_kernel_v134(opus_attn_kargs); // v134
 template<class T> __global__ void opus_attn_gfx1201_kernel_v135(opus_attn_kargs); // v135
+template<class T> __global__ void opus_attn_gfx1201_kernel_v136(opus_attn_kargs); // v136
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -216,6 +217,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 133: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v133<opus_attn_traits<128, 32, 128>>); break;
         case 134: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v134<opus_attn_traits<128, 32, 128>>); break;
         case 135: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v135<opus_attn_traits<128, 32, 128>>); break;
+        case 136: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v136<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -306,7 +308,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135 || version == 136) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -77,6 +77,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v109(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v110(opus_attn_kargs); // v110
 template<class T> __global__ void opus_attn_gfx1201_kernel_v111(opus_attn_kargs); // v111
 template<class T> __global__ void opus_attn_gfx1201_kernel_v112(opus_attn_kargs); // v112
+template<class T> __global__ void opus_attn_gfx1201_kernel_v113(opus_attn_kargs); // v113
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -170,6 +171,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 110: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v110<opus_attn_traits<128, 32, 128>>); break;
         case 111: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v111<opus_attn_traits<128, 32, 128>>); break;
         case 112: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v112<opus_attn_traits<128, 32, 128>>); break;
+        case 113: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v113<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -102,6 +102,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v134(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v135(opus_attn_kargs); // v135
 template<class T> __global__ void opus_attn_gfx1201_kernel_v136(opus_attn_kargs); // v136
 template<class T> __global__ void opus_attn_gfx1201_kernel_v137(opus_attn_kargs); // v137
+template<class T> __global__ void opus_attn_gfx1201_kernel_v138(opus_attn_kargs); // v138
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -220,6 +221,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 135: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v135<opus_attn_traits<128, 32, 128>>); break;
         case 136: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v136<opus_attn_traits<128, 32, 128>>); break;
         case 137: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v137<opus_attn_traits<128, 32, 128>>); break;
+        case 138: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v138<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -310,7 +312,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135 || version == 136 || version == 137) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135 || version == 136 || version == 137 || version == 138) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -94,6 +94,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v126(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v127(opus_attn_kargs); // v127
 template<class T> __global__ void opus_attn_gfx1201_kernel_v128(opus_attn_kargs); // v128
 template<class T> __global__ void opus_attn_gfx1201_kernel_v129(opus_attn_kargs); // v129
+template<class T> __global__ void opus_attn_gfx1201_kernel_v130(opus_attn_kargs); // v130
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -204,6 +205,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 127: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v127<opus_attn_traits<128, 32, 128>>); break;
         case 128: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v128<opus_attn_traits<128, 32, 128>>); break;
         case 129: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v129<opus_attn_traits<128, 32, 128>>); break;
+        case 130: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v130<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -294,7 +296,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -73,6 +73,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v105(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v106(opus_attn_kargs); // v106
 template<class T> __global__ void opus_attn_gfx1201_kernel_v107(opus_attn_kargs); // v107
 template<class T> __global__ void opus_attn_gfx1201_kernel_v108(opus_attn_kargs); // v108
+template<class T> __global__ void opus_attn_gfx1201_kernel_v109(opus_attn_kargs); // v109
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -162,6 +163,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 106: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v106<opus_attn_traits<128, 32, 128>>); break;
         case 107: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v107<opus_attn_traits<128, 32, 128>>); break;
         case 108: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v108<opus_attn_traits<128, 32, 128>>); break;
+        case 109: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v109<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -252,7 +254,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -71,6 +71,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v103(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v104(opus_attn_kargs); // v104
 template<class T> __global__ void opus_attn_gfx1201_kernel_v105(opus_attn_kargs); // v105
 template<class T> __global__ void opus_attn_gfx1201_kernel_v106(opus_attn_kargs); // v106
+template<class T> __global__ void opus_attn_gfx1201_kernel_v107(opus_attn_kargs); // v107
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -158,6 +159,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 104: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v104<opus_attn_traits<128, 32, 128>>); break;
         case 105: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v105<opus_attn_traits<128, 32, 128>>); break;
         case 106: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v106<opus_attn_traits<128, 32, 128>>); break;
+        case 107: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v107<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -248,7 +250,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -75,6 +75,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v107(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v108(opus_attn_kargs); // v108
 template<class T> __global__ void opus_attn_gfx1201_kernel_v109(opus_attn_kargs); // v109
 template<class T> __global__ void opus_attn_gfx1201_kernel_v110(opus_attn_kargs); // v110
+template<class T> __global__ void opus_attn_gfx1201_kernel_v111(opus_attn_kargs); // v111
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -166,6 +167,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 108: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v108<opus_attn_traits<128, 32, 128>>); break;
         case 109: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v109<opus_attn_traits<128, 32, 128>>); break;
         case 110: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v110<opus_attn_traits<128, 32, 128>>); break;
+        case 111: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v111<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -256,7 +258,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -69,6 +69,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v101(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v102(opus_attn_kargs); // v102
 template<class T> __global__ void opus_attn_gfx1201_kernel_v103(opus_attn_kargs); // v103
 template<class T> __global__ void opus_attn_gfx1201_kernel_v104(opus_attn_kargs); // v104
+template<class T> __global__ void opus_attn_gfx1201_kernel_v105(opus_attn_kargs); // v105
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -154,6 +155,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 102: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v102<opus_attn_traits<128, 32, 128>>); break;
         case 103: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v103<opus_attn_traits<128, 32, 128>>); break;
         case 104: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v104<opus_attn_traits<128, 32, 128>>); break;
+        case 105: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v105<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -244,7 +246,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -99,6 +99,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v131(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v132(opus_attn_kargs); // v132
 template<class T> __global__ void opus_attn_gfx1201_kernel_v133(opus_attn_kargs); // v133
 template<class T> __global__ void opus_attn_gfx1201_kernel_v134(opus_attn_kargs); // v134
+template<class T> __global__ void opus_attn_gfx1201_kernel_v135(opus_attn_kargs); // v135
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -214,6 +215,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 132: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v132<opus_attn_traits<128, 32, 128>>); break;
         case 133: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v133<opus_attn_traits<128, 32, 128>>); break;
         case 134: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v134<opus_attn_traits<128, 32, 128>>); break;
+        case 135: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v135<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -304,7 +306,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -98,6 +98,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v130(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v131(opus_attn_kargs); // v131
 template<class T> __global__ void opus_attn_gfx1201_kernel_v132(opus_attn_kargs); // v132
 template<class T> __global__ void opus_attn_gfx1201_kernel_v133(opus_attn_kargs); // v133
+template<class T> __global__ void opus_attn_gfx1201_kernel_v134(opus_attn_kargs); // v134
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -212,6 +213,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 131: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v131<opus_attn_traits<128, 32, 128>>); break;
         case 132: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v132<opus_attn_traits<128, 32, 128>>); break;
         case 133: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v133<opus_attn_traits<128, 32, 128>>); break;
+        case 134: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v134<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -302,7 +304,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -65,6 +65,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v44(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v45(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v48(opus_attn_kargs);
 template<class T> __global__ void opus_attn_gfx1201_kernel_v100(opus_attn_kargs); // v100
+template<class T> __global__ void opus_attn_gfx1201_kernel_v101(opus_attn_kargs); // v101
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -146,6 +147,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 48: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v48<opus_attn_traits<128, 32, 128>>); break;
         case 49: launch_v49_asm(k); break;
         case 100: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v100<opus_attn_traits<128, 32, 128>>); break;
+        case 101: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v101<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -236,7 +238,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -74,6 +74,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v106(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v107(opus_attn_kargs); // v107
 template<class T> __global__ void opus_attn_gfx1201_kernel_v108(opus_attn_kargs); // v108
 template<class T> __global__ void opus_attn_gfx1201_kernel_v109(opus_attn_kargs); // v109
+template<class T> __global__ void opus_attn_gfx1201_kernel_v110(opus_attn_kargs); // v110
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -164,6 +165,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 107: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v107<opus_attn_traits<128, 32, 128>>); break;
         case 108: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v108<opus_attn_traits<128, 32, 128>>); break;
         case 109: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v109<opus_attn_traits<128, 32, 128>>); break;
+        case 110: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v110<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -254,7 +256,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -97,6 +97,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v129(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v130(opus_attn_kargs); // v130
 template<class T> __global__ void opus_attn_gfx1201_kernel_v131(opus_attn_kargs); // v131
 template<class T> __global__ void opus_attn_gfx1201_kernel_v132(opus_attn_kargs); // v132
+template<class T> __global__ void opus_attn_gfx1201_kernel_v133(opus_attn_kargs); // v133
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -210,6 +211,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 130: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v130<opus_attn_traits<128, 32, 128>>); break;
         case 131: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v131<opus_attn_traits<128, 32, 128>>); break;
         case 132: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v132<opus_attn_traits<128, 32, 128>>); break;
+        case 133: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v133<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -300,7 +302,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -101,6 +101,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v133(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v134(opus_attn_kargs); // v134
 template<class T> __global__ void opus_attn_gfx1201_kernel_v135(opus_attn_kargs); // v135
 template<class T> __global__ void opus_attn_gfx1201_kernel_v136(opus_attn_kargs); // v136
+template<class T> __global__ void opus_attn_gfx1201_kernel_v137(opus_attn_kargs); // v137
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -218,6 +219,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 134: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v134<opus_attn_traits<128, 32, 128>>); break;
         case 135: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v135<opus_attn_traits<128, 32, 128>>); break;
         case 136: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v136<opus_attn_traits<128, 32, 128>>); break;
+        case 137: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v137<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -308,7 +310,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135 || version == 136) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118 || version == 119 || version == 120 || version == 121 || version == 122 || version == 123 || version == 124 || version == 125 || version == 126 || version == 127 || version == 128 || version == 129 || version == 130 || version == 131 || version == 132 || version == 133 || version == 134 || version == 135 || version == 136 || version == 137) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_host.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_host.cc
@@ -82,6 +82,7 @@ template<class T> __global__ void opus_attn_gfx1201_kernel_v114(opus_attn_kargs)
 template<class T> __global__ void opus_attn_gfx1201_kernel_v115(opus_attn_kargs); // v115
 template<class T> __global__ void opus_attn_gfx1201_kernel_v116(opus_attn_kargs); // v116
 template<class T> __global__ void opus_attn_gfx1201_kernel_v117(opus_attn_kargs); // v117
+template<class T> __global__ void opus_attn_gfx1201_kernel_v118(opus_attn_kargs); // v118
 __global__ void v_transpose_kernel(const bf16_t*, bf16_t*, int, int, int, int);
 
 template<int BM, int BN, class K>
@@ -180,6 +181,7 @@ static void run_opus_attn_gfx1201(int version, opus_attn_kargs k) {
         case 115: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v115<opus_attn_traits<128, 32, 128>>); break;
         case 116: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v116<opus_attn_traits<128, 32, 128>>); break;
         case 117: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v117<opus_attn_traits<128, 32, 128>>); break;
+        case 118: launch_<128, 32>(k, opus_attn_gfx1201_kernel_v118<opus_attn_traits<128, 32, 128>>); break;
         default: fprintf(stderr, "unknown --version=%d\n", version); std::exit(1);
     }
 }
@@ -270,7 +272,7 @@ int main(int argc, char** argv) {
     }
 
     opus_attn_kargs kargs{};
-    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117) ? dVT : dV); kargs.ptr_o = dO;
+    kargs.ptr_q = dQ; kargs.ptr_k = dK; kargs.ptr_v = ((version == 9 || version == 10 || version == 34 || version == 35 || version == 36 || version == 37 || version == 38 || version == 39 || version == 40 || version == 41 || version == 42 || version == 43 || version == 44 || version == 45 || version == 48 || version == 49 || version == 100 || version == 101 || version == 102 || version == 103 || version == 104 || version == 105 || version == 106 || version == 107 || version == 108 || version == 109 || version == 110 || version == 111 || version == 114 || version == 115 || version == 116 || version == 117 || version == 118) ? dVT : dV); kargs.ptr_o = dO;
     kargs.B = B; kargs.H = H; kargs.N = N; kargs.D = D; kargs.scale = scale;
 
     // Warmup

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v100.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v100.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v100_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v100<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v100_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v100_template.hpp
@@ -1,0 +1,192 @@
+// v100 -- v39 + K-load software pipelining in QK^T (v63 pattern), PV left as v39.
+//
+// Base choice: v39 is the measured best on this box (the fused-PV-rescale family).
+// v43's batched pre-PV rescale did NOT help here, so v100 keeps v39's structure
+// verbatim and changes ONLY the K-load scheduling in QK^T.
+//
+// Hypothesis: in QK^T the WMMA for D-tile dt waits on its own global K load, exposing
+// VMEM latency at the head of every D-tile. The v63 idea (preload D-tile 0, then issue
+// dt+1's K loads before the WMMAs on dt) lets the global fetch overlap the ~12.6-cyc
+// bf16 WMMA issue window. This is pure load reordering — the arithmetic is
+// byte-for-byte identical to v39, so the result is bit-exact.
+//
+// NOTE: I also tried mirroring this for V in the PV phase (v78 pattern). Measured on
+// this box it REGRESSED (12.29ms K-only -> 13.02ms K+V): the extra V next-buffer
+// inflates VGPR liveness exactly where the fp32x8 O accumulator pressure peaks, and
+// the compiler already schedules the V loads well. So PV keeps v39's direct loads.
+//
+// VGPR cost: +2 bf16x8 (K next-buffer) live across QK^T only (~8 VGPR) over v39's
+// ~205, staying well under 256 -> keeps 7 waves/SIMD. No LDS, no barriers, no change
+// to the softmax / online-rescale math.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast100(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v100_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v100_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v100(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast100(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v100_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v100_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast100(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast100(v_s1[j]);
+
+        // ---- PV: two WMMAs per D-tile, rescale fused per D-tile (v39 structure).
+        // Software-pipelined V loads: preload D-tile 0, then issue dt+1's V loads
+        // before the WMMAs on dt.
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast100(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v101.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v101.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v101_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v101<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v101_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v101_template.hpp
@@ -1,0 +1,208 @@
+// v101 -- v100 + DEEPER (two-ahead) K-load prefetch in QK^T. PV left as v100/v39.
+//
+// Base choice: v100 (the round-1 winner, 89.0 TFLOPS) = v39 + one-stage K prefetch
+// in QK^T. Round-1 reviewer's #1 next lever: "Try QK two-ahead K prefetch as a
+// controlled ablation. One-stage prefetch improved, so the remaining bottleneck may
+// still be residual K VMEM latency; test kt+2 lookahead only in QK."
+//
+// Hypothesis: a single-stage prefetch (v100) only overlaps ONE D-tile's WMMA issue
+// window (~12.6 cyc per bf16 WMMA, 2 per D-tile) with the next K fetch. Global VMEM
+// latency on RDNA4 is ~hundreds of cycles, so one D-tile of slack is not enough to
+// fully hide it; the head of the loop still stalls on the first uncovered fetch. A
+// two-ahead ring (issue kt+2's K loads while WMMA on kt runs) doubles the in-flight
+// fetch distance to ~2 D-tiles (~50 cyc of WMMA issue + the deeper VMEM scoreboard),
+// letting the load/use gap shrink further. Pure load reordering -> arithmetic is
+// byte-for-byte identical to v39/v100 -> bit-exact.
+//
+// VGPR cost: ring holds 2 in-flight K stages = 4 bf16x8 (v_k0/1 for kt and kt+1)
+// instead of v100's 2. That is ~+8 VGPR (16 bf16 = 8 VGPR) over v100, live across
+// QK^T only (dead before PV where the fp32x8 O accumulator pressure peaks). Estimated
+// ~213 VGPR vs v100's ~205 -> still <256, still 7 waves/SIMD. RISK: if it tips over a
+// VGPR cliff occupancy drops 7->6 and it regresses; that is the explicit gate.
+// PV keeps v100's direct V loads (V double-buffer was a measured regression).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast101(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v101_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v101_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v101(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast101(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101): a 2-entry ring keeps kt and
+        // kt+1's K fragments preloaded; iteration kt consumes its slot and immediately
+        // issues kt+2's loads into the same slot before the WMMAs run. This doubles the
+        // in-flight K fetch distance vs v100's single-stage prefetch to better hide
+        // global VMEM latency behind the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        // Preload the first two D-tiles into the ring.
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v101_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v101_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast101(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast101(v_s1[j]);
+
+        // ---- PV: two WMMAs per D-tile, rescale fused per D-tile (v39 structure).
+        // Direct (non-pipelined) V loads: a V next-buffer was measured to REGRESS on
+        // this box (inflates VGPR liveness where the fp32x8 O accumulator peaks), so PV
+        // keeps v39/v100's direct loads and lets the compiler+HW scoreboard overlap.
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast101(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v102.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v102.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v102_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v102<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v102_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v102_template.hpp
@@ -1,0 +1,228 @@
+// v102 -- v101 (two-ahead QK K-prefetch ring) + the v43 BATCHED PRE-PV RESCALE.
+//
+// Base choice: v101 (round-2 winner, 89.15 TFLOPS) = v39 + two-ahead K-prefetch ring
+// in QK^T. The round-2 gain over v100 was tiny (+0.15), so QK K VMEM latency is no
+// longer the dominant limiter; the limit is now mixed (QK WMMA cadence + softmax +
+// PV V-load latency). v101 inherited a STRUCTURAL gap from its v39 lineage that the
+// reviewer's K-prefetch ablations never touched.
+//
+// THE GAP: v39/v100/v101 all perform the online-softmax rescale of the 8 O
+// accumulators INSIDE the per-D-tile PV loop (a `if (need_rescale) v_o[dt][j]*=...`
+// guard fused with the two PV WMMAs and the V loads). That interleaves a VALU-only
+// op (the rescale FMA) with the memory-issuing op (the V global loads) on the SAME
+// loop iteration, so the scheduler cannot freely hoist the V loads ahead of the
+// rescale work. v43 (MEASURED on this box: v39 88.7 -> v43 90.6, +1.9 TFLOPS) fixed
+// exactly this by hoisting the rescale into ONE branch-guarded VALU-only pass over
+// all 8 v_o BEFORE the PV loop. The PV loop then becomes pure (V-load + WMMA), so the
+// compiler/HW scoreboard can issue all the V loads early and overlap them with the
+// rescale FMAs of the preceding pass. This is playbook lever #1.
+//
+// v102 = v101's QK K-prefetch ring (hides QK K latency) + v43's batched rescale
+// (separates the VALU rescale from the V-load-issuing PV loop). The two levers are
+// ORTHOGONAL: one targets QK load latency, the other the PV phase's load/VALU mix.
+// Expected ~ additive: v101's 89.15 plus a fraction of v43's +1.9 PV-phase win.
+//
+// BIT-EXACTNESS: each v_o[dt] is independent across dt, and for every dt the rescale
+// multiply `v_o[dt][j] *= rescale` still happens BEFORE that dt's PV WMMAs and with
+// the identical `rescale = exp2(m_old-m_new)` value. Moving all 8 multiplies into a
+// loop that runs just before the PV loop does not change which values are multiplied,
+// the multiplier, or the WMMA accumulation order -> byte-for-byte identical FP result.
+// Verified-equivalent transform; v43 already passed the n_bad==0 gate with it.
+//
+// VGPR: identical to v101 in the PV phase (same v_o[DK], same direct V loads, V
+// double-buffer remains a measured regression and is NOT added). The batched-rescale
+// pass uses no new live state. Expected ~213 VGPR (== v101), 7 waves/SIMD, 0 spill.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast102(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v102_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v102_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v102(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast102(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v102): a 2-entry ring keeps kt and
+        // kt+1's K fragments preloaded; iteration kt consumes its slot and immediately
+        // issues kt+2's loads into the same slot before the WMMAs run. This doubles the
+        // in-flight K fetch distance vs v100's single-stage prefetch to better hide
+        // global VMEM latency behind the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        // Preload the first two D-tiles into the ring.
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v102_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+            // v43 BATCHED rescale: apply to ALL 8 O accumulators here, in one
+            // VALU-only pass, BEFORE the PV loop. This frees the PV loop to be pure
+            // (V-load + WMMA) so the scheduler can issue the V global loads early and
+            // overlap them with these rescale FMAs. Bit-identical to the per-D-tile
+            // fused rescale (same value, same per-dt ordering before each PV WMMA).
+            #pragma unroll
+            for (int dt = 0; dt < DK; ++dt) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v102_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast102(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast102(v_s1[j]);
+
+        // ---- PV: two WMMAs per D-tile. Rescale already applied above (v43 batched
+        // pass) so this loop is PURE V-load + WMMA -> the scheduler can hoist all the
+        // V global loads ahead and overlap them with the preceding rescale FMAs.
+        // Direct (non-pipelined) V loads: a V next-buffer was measured to REGRESS on
+        // this box (inflates VGPR liveness where the fp32x8 O accumulator peaks), so PV
+        // keeps v39/v100's direct loads and lets the compiler+HW scoreboard overlap.
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast102(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v103.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v103.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v103_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v103<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v103_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v103_template.hpp
@@ -1,0 +1,226 @@
+// v103 -- v101 (two-ahead K prefetch in QK^T) + HYBRID 2-D-tile GROUPED PV rescale.
+//
+// Base choice: v101 (the running best, 89.15 TFLOPS) = v100 + two-ahead K ring in
+// QK^T. QK^T is kept BYTE-FOR-BYTE identical to v101. The ONLY change is the PV phase.
+//
+// Round-3 result: v102 hoisted the rescale of ALL 8 O accumulators into one batched
+// pass before PV (v43 style). It REGRESSED to 87.25 (vs v101 89.15). Root cause per
+// reviewer: the all-8 rescale writes form one long VALU dependency block that must
+// retire before ANY PV WMMA can accumulate, so the matrix pipe starves at the head of
+// PV and WMMA issue cadence drops. v101's per-dt fusion (rescale one acc, load its V,
+// 2 WMMAs) keeps short independent windows but exposes only ONE dependent WMMA chain
+// at a time (v_o[dt] -> v_o[dt]) and re-evaluates the need_rescale branch 8x.
+//
+// Hypothesis (reviewer's explicit NEXT FOCUS): a HYBRID grouping of 2 D-tiles is the
+// sweet spot. Process dt in pairs (dt, dt+1): rescale BOTH accumulators, issue all 4
+// V loads for the pair, then the 4 WMMAs. This exposes TWO INDEPENDENT WMMA chains
+// (v_o[dt] and v_o[dt+1] never alias) so the matrix pipe can interleave them and hide
+// each WMMA's ~12.6-cyc result latency behind the other chain -- better issue cadence
+// than v101's single-chain-per-region. The 4 concurrent V loads add memory-level
+// parallelism. Crucially the rescale block is only 2 accumulators (16 FMAs) deep, not
+// 8 (64 FMAs), so PV WMMA can start after a short prefix instead of v102's long stall.
+//
+// Arithmetic is identical to v101: each v_o[dt] is rescaled exactly once before its
+// PV accumulation, same WMMA operand order, same rescale value -> bit-exact in bf16.
+// VGPR: same accumulators, V buffers transient per pair (4 bf16x8 live briefly, same
+// as v101's 2 + the next pair the compiler may overlap). No new persistent state vs
+// v101 -> occupancy unchanged. RISK: low; if grouping helps nothing it ties v101.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast103(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v103_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v103_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v103(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast103(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101): a 2-entry ring keeps kt and
+        // kt+1's K fragments preloaded; iteration kt consumes its slot and immediately
+        // issues kt+2's loads into the same slot before the WMMAs run. This doubles the
+        // in-flight K fetch distance vs v100's single-stage prefetch to better hide
+        // global VMEM latency behind the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        // Preload the first two D-tiles into the ring.
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v103_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v103_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast103(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast103(v_s1[j]);
+
+        // ---- PV: HYBRID 2-D-tile grouped rescale (v103). Process D-tiles in pairs
+        // (dt, dt+1): rescale BOTH O accumulators, issue all 4 V loads for the pair,
+        // then 4 WMMAs across two INDEPENDENT accumulator chains (v_o[dt], v_o[dt+1]
+        // never alias) so the matrix pipe can interleave them and hide each WMMA's
+        // result latency behind the other chain. Rescale block is only 2 accumulators
+        // deep (vs v102's 8) so PV WMMA starts after a short prefix, not a long stall.
+        // DK=8 is even -> exact pairing, no remainder. V loads stay direct (a V
+        // next-buffer was a measured regression on this box).
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j]  *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt1][j] *= rescale;
+            }
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast103(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v104.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v104.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v104_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v104<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v104_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v104_template.hpp
@@ -1,0 +1,248 @@
+// v104 -- v101 (two-ahead K prefetch in QK^T) + 4-D-TILE GROUPED PV with four
+// independent accumulator chains and STAGGERED WMMA order.
+//
+// Base choice: v103 (the running best, 89.68 TFLOPS) which itself is v101's QK^T
+// (two-ahead K ring) + a HYBRID 2-D-tile grouped PV rescale. QK^T is kept
+// BYTE-FOR-BYTE identical to v101/v103. The ONLY change is the PV phase grouping.
+//
+// History on the PV phase:
+//   v101: per-dt fusion -> exposes only ONE dependent WMMA chain at a time
+//         (v_o[dt] -> v_o[dt]); the matrix pipe cannot hide the ~12.6-cyc WMMA
+//         result latency, so cadence is single-chain limited.
+//   v102: hoist rescale of ALL 8 accumulators -> 64-deep VALU prefix stalls the
+//         matrix pipe at PV entry. REGRESSED to 87.25.
+//   v103: HYBRID 2-D-tile grouping -> TWO independent chains + 16-FMA rescale
+//         prefix. Best so far at 89.68, but reviewer notes two chains are still
+//         insufficient to FULLY hide WMMA result latency on wave32 WMMA (one
+//         intervening independent WMMA does not cover the whole latency).
+//
+// Hypothesis (reviewer's explicit NEXT FOCUS): process D-tiles in groups of 4 ->
+// FOUR independent accumulator chains (v_o[dt..dt+3] never alias). With the
+// staggered WMMA order [dt.p0, dt1.p0, dt2.p0, dt3.p0, dt.p1, dt1.p1, dt2.p1,
+// dt3.p1], the second WMMA touching v_o[dt] (dt.p1) is issued 4 WMMAs after the
+// first (dt.p0). That puts THREE independent WMMAs between the producer and
+// consumer of every accumulator -- enough to fully cover the result latency and
+// keep the matrix pipe at full issue cadence, unlike v103's single-WMMA spacing.
+// The rescale prefix stays bounded: 4 accumulators (32 FMAs) per group, NOT the
+// full 8 (64 FMAs) that stalled v102; and 8 V loads per group give deeper
+// memory-level parallelism than v103's 4.
+//
+// Arithmetic is identical to v101/v103: each v_o[dt] is rescaled exactly once
+// before its PV accumulation, same WMMA operand order per accumulator (p0 before
+// p1), same rescale value -> bit-exact in bf16. The staggering only reorders
+// WMMAs across DISTINCT (non-aliasing) accumulators, which is associativity-safe
+// because each accumulator's own update sequence is preserved.
+// VGPR: 8 transient bf16x8 V fragments live per group (vs v103's 4). DK=8 -> two
+// groups of 4, no remainder. RISK: low-med; extra V-fragment liveness could
+// nudge VGPR pressure; if it regresses, v103's 2-wide remains the fallback.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast104(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v104_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v104_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v104(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast104(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101): a 2-entry ring keeps kt and
+        // kt+1's K fragments preloaded; iteration kt consumes its slot and immediately
+        // issues kt+2's loads into the same slot before the WMMAs run. This doubles the
+        // in-flight K fetch distance vs v100's single-stage prefetch to better hide
+        // global VMEM latency behind the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        // Preload the first two D-tiles into the ring.
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v104_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v104_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast104(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast104(v_s1[j]);
+
+        // ---- PV: 4-D-tile grouped rescale (v104). Process D-tiles in groups of 4
+        // (dt, dt+1, dt+2, dt+3): rescale all four O accumulators (32-FMA prefix),
+        // issue all 8 V loads for the group, then 8 WMMAs in STAGGERED order across
+        // FOUR INDEPENDENT accumulator chains. The order issues every chain's p0
+        // WMMA first, then every chain's p1 WMMA, so the second WMMA on any given
+        // accumulator is 4 WMMAs after its first -> three independent WMMAs cover
+        // the result latency, keeping the matrix pipe at full cadence. DK=8 is
+        // divisible by 4 -> two groups, no remainder. V loads stay direct.
+        #pragma unroll
+        for (int dg = 0; dg < DK; dg += 4) {
+            const int d0 = dg, d1 = dg + 1, d2 = dg + 2, d3 = dg + 3;
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d0][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d1][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d3][j] *= rescale;
+            }
+            // Eight V fragments: two 16-wide subtiles (p0/p1 columns) per D-tile.
+            const bf16_t* p0base = VTp + n_base + row8;
+            const bf16_t* p1base = VTp + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d0 * W_K + col16) * vt_stride_d);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d0 * W_K + col16) * vt_stride_d);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d1 * W_K + col16) * vt_stride_d);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d1 * W_K + col16) * vt_stride_d);
+            bf16x8_t vc0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d2 * W_K + col16) * vt_stride_d);
+            bf16x8_t vc1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d2 * W_K + col16) * vt_stride_d);
+            bf16x8_t vd0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d3 * W_K + col16) * vt_stride_d);
+            bf16x8_t vd1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d3 * W_K + col16) * vt_stride_d);
+            // Staggered: all four p0 WMMAs first (independent chains), then all p1.
+            v_o[d0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[d0]);
+            v_o[d1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[d1]);
+            v_o[d2] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vc0, v_p0, v_o[d2]);
+            v_o[d3] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vd0, v_p0, v_o[d3]);
+            v_o[d0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[d0]);
+            v_o[d1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[d1]);
+            v_o[d2] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vc1, v_p1, v_o[d2]);
+            v_o[d3] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vd1, v_p1, v_o[d3]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast104(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v105.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v105.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v105_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v105<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v105_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v105_template.hpp
@@ -1,0 +1,257 @@
+// v105 -- v103 (two-ahead K prefetch QK^T + hybrid 2-wide PV) PV phase replaced with
+// a 4-CHAIN, LOW-LIVE, TWO-WAVE just-in-time V load (reviewer's explicit NEXT FOCUS #2).
+//
+// Base choice: v103 (the running best, 89.68 TFLOPS) = v101's QK^T (two-ahead K ring)
+// + a hybrid 2-D-tile grouped PV rescale. QK^T is kept BYTE-FOR-BYTE identical to
+// v101/v103. The ONLY change is the PV phase grouping/scheduling.
+//
+// History on the PV phase:
+//   v101: per-dt fusion -> only ONE dependent WMMA chain live at a time
+//         (v_o[dt] -> v_o[dt]); cannot hide the ~12.6-cyc WMMA result latency.
+//   v102: hoist rescale of ALL 8 accumulators -> 64-deep VALU prefix stalls the
+//         matrix pipe at PV entry. REGRESSED to 87.25.
+//   v103: hybrid 2-D-tile grouping -> TWO independent chains + 16-FMA rescale prefix.
+//         Best so far at 89.68. Two chains only put ONE independent WMMA between an
+//         accumulator's producer and consumer -> partial latency cover.
+//   v104: 4-D-tile group BUT made all EIGHT V fragments (va0/va1..vd0/vd1) live at
+//         once, then 8 WMMAs. REGRESSED HARD to 82.23. Reviewer root cause: 8 live
+//         bf16x8 V fragments on top of the 64-fp32/lane v_o accumulator inflated
+//         VGPR live ranges around the WMMA window -> spills / waitcnt-constrained
+//         scheduling. Lesson: 4 chains help, but 8 live fragments is the cliff.
+//
+// Hypothesis (reviewer NEXT FOCUS #2 -- "Keep 4 chains but load just-in-time in two
+// waves: load/use p0 for four chains, then load/use p1"): process D-tiles in groups
+// of 4 to expose FOUR independent accumulator chains, but NEVER hold more than 4 V
+// fragments live. Per group:
+//   1. rescale the 4 group accumulators (32-FMA bounded prefix, like v104, not v102).
+//   2. WAVE p0: load va0,vb0,vc0,vd0 (the 4 p0-column V tiles), issue the 4 p0 WMMAs
+//      across the four INDEPENDENT chains v_o[d0..d3]. 4 live fragments.
+//   3. WAVE p1: load va1,vb1,vc1,vd1 (reusing the same 4 registers), issue the 4 p1
+//      WMMAs. 4 live fragments.
+// The second WMMA touching v_o[d0] (its p1) is separated from the first (its p0) by
+// THREE independent p0 WMMAs PLUS the 4 p1 V loads -> the producer->consumer distance
+// is at least as large as v104's, fully covering the result latency. But peak live V
+// fragments is 4 (== v103, half of v104), so VGPR pressure stays at the v103 level
+// that did NOT spill. This isolates the "4 independent chains" win from the "8 live
+// fragments" regression that sank v104.
+//
+// Arithmetic is identical to v101/v103/v104: each v_o[dt] rescaled exactly once before
+// its PV accumulation, same per-accumulator WMMA order (p0 before p1), same rescale
+// value -> bit-exact in bf16. Reordering WMMAs only across DISTINCT (non-aliasing)
+// accumulators is associativity-safe; each accumulator's own update sequence is intact.
+// VGPR: peak 4 transient bf16x8 V fragments (== v103). DK=8 -> two groups of 4, no
+// remainder. RISK: low; if the two-wave split serializes loads against WMMA it ties
+// v103, and v103 remains the fallback. (Requires DK % 4 == 0; true for D=128.)
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast105(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v105_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v105_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v105(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast105(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101): a 2-entry ring keeps kt and
+        // kt+1's K fragments preloaded; iteration kt consumes its slot and immediately
+        // issues kt+2's loads into the same slot before the WMMAs run.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v105_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v105_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast105(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast105(v_s1[j]);
+
+        // ---- PV: 4-CHAIN, LOW-LIVE, TWO-WAVE just-in-time V load (v105).
+        // Process D-tiles in groups of 4 -> four INDEPENDENT accumulator chains
+        // v_o[d0..d3] (never alias). Within each group, load V in two waves so at most
+        // 4 bf16x8 V fragments are ever live (== v103), avoiding v104's 8-fragment
+        // VGPR cliff. Wave p0: load the four p0-column tiles, issue the four p0 WMMAs.
+        // Wave p1: reload into the same regs, issue the four p1 WMMAs. The producer of
+        // v_o[d0] (its p0 WMMA) and its consumer (its p1 WMMA) are separated by three
+        // independent p0 WMMAs + four p1 loads -> full result-latency cover.
+        #pragma unroll
+        for (int dg = 0; dg < DK; dg += 4) {
+            const int d0 = dg, d1 = dg + 1, d2 = dg + 2, d3 = dg + 3;
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d0][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d1][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[d3][j] *= rescale;
+            }
+            const bf16_t* p0base = VTp + n_base + row8;
+            const bf16_t* p1base = VTp + n_base + 16 + row8;
+
+            // Wave p0: 4 live V fragments, 4 WMMAs over the four independent chains.
+            {
+                bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d0 * W_K + col16) * vt_stride_d);
+                bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d1 * W_K + col16) * vt_stride_d);
+                bf16x8_t vc0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d2 * W_K + col16) * vt_stride_d);
+                bf16x8_t vd0 = *reinterpret_cast<const bf16x8_t*>(p0base + (d3 * W_K + col16) * vt_stride_d);
+                v_o[d0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[d0]);
+                v_o[d1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[d1]);
+                v_o[d2] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vc0, v_p0, v_o[d2]);
+                v_o[d3] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vd0, v_p0, v_o[d3]);
+            }
+            // Wave p1: same 4 registers reused, 4 WMMAs over the four independent chains.
+            {
+                bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d0 * W_K + col16) * vt_stride_d);
+                bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d1 * W_K + col16) * vt_stride_d);
+                bf16x8_t vc1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d2 * W_K + col16) * vt_stride_d);
+                bf16x8_t vd1 = *reinterpret_cast<const bf16x8_t*>(p1base + (d3 * W_K + col16) * vt_stride_d);
+                v_o[d0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[d0]);
+                v_o[d1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[d1]);
+                v_o[d2] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vc1, v_p1, v_o[d2]);
+                v_o[d3] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vd1, v_p1, v_o[d3]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast105(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v106.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v106.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v106_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v106<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v106_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v106_template.hpp
@@ -1,0 +1,234 @@
+// v106 -- v103 (best, 89.68 TFLOPS) + ONE-PAIR-AHEAD SOFTWARE-PIPELINED PV RESCALE.
+//
+// Base choice: v103 (the running best). QK^T is kept BYTE-FOR-BYTE identical to v103
+// (two-ahead K prefetch ring). The PV phase retains v103's proven 2-D-tile grouped
+// structure -- exactly 4 V fragments live at any moment, two independent accumulator
+// chains (v_o[dt], v_o[dt+1]) per pair. v104 (4-chain, 8 live frags) and v105 (4-chain
+// JIT two-wave) both REGRESSED by widening the D group; we do NOT widen it again.
+//
+// What changed vs v103 (the ONLY change): the online rescale of the O accumulators is
+// software-pipelined by ONE PAIR. v103 rescales pair (dt,dt+1) at the HEAD of that
+// pair's iteration, so v_o[dt] *= rescale forms a short VALU dependency that the very
+// next PV WMMA on v_o[dt] must wait for -- the matrix pipe stalls on rescale at each
+// pair head. v102 tried hoisting ALL 8 rescales into one prologue and regressed: the
+// 64-FMA block must retire before ANY PV WMMA can accumulate, starving the matrix pipe
+// at the head of PV.
+//
+// v106 splits the difference with a true pipeline: a PROLOGUE rescales only pair 0
+// (16 FMAs), then iteration `dt` issues the current pair's 4 V loads, interleaves the
+// NEXT pair's rescale (v_o[dt+2], v_o[dt+3] -- DIFFERENT registers, independent of the
+// current pair's WMMAs) between the loads and the WMMAs, then issues the current pair's
+// 4 WMMAs. The next-pair rescale FMAs thus execute in the shadow of (a) the current
+// V-load s_waitcnt latency and (b) the current WMMA issue window -- VALU on the SALU/
+// VALU path overlapping memory + matrix pipe. By the time iteration dt+2 runs, its
+// accumulators are already rescaled, so its WMMAs issue with NO rescale dependency at
+// their head. This is playbook lever 1 ("separate memory-issuing loops from VALU-only
+// loops") + lever 2 (cross-pipe interleave) applied at PAIR granularity, avoiding both
+// v103's per-pair head stall AND v102's all-8 prologue stall.
+//
+// Arithmetic identical to v103: each v_o[dt] is rescaled EXACTLY ONCE before its PV
+// accumulation, same rescale value, same WMMA operand order -> bit-exact in bf16.
+// VGPR: same accumulators, same 4-live-V-fragment footprint as v103 -> occupancy
+// unchanged. RISK: low; if the compiler already reordered v103's rescale this way it
+// simply ties v103.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast106(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v106_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v106_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v106(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast106(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v106_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v106_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast106(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast106(v_s1[j]);
+
+        // ---- PV: v103's 2-D-tile grouped PV (4 live V fragments, two independent
+        // accumulator chains per pair) with the online rescale SOFTWARE-PIPELINED BY
+        // ONE PAIR. Prologue rescales pair 0; iteration dt then issues the current
+        // pair's 4 V loads, interleaves the NEXT pair's rescale (independent regs)
+        // between loads and WMMAs, and issues the current pair's 4 WMMAs. Each
+        // accumulator is rescaled exactly once before its PV WMMA -> bit-exact.
+        // DK=8 is even -> exact pairing, no remainder.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale: prepare the NEXT pair's accumulators while the
+            // current pair's V loads are in flight. Independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast106(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v107.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v107.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v107_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v107<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v107_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v107_template.hpp
@@ -1,0 +1,237 @@
+// v107 -- v106 (best, 90.2 TFLOPS) + MID-LOAD one-pair-ahead PV rescale placement.
+//
+// Base choice: v106 (the running best). QK^T is kept BYTE-FOR-BYTE identical to v106
+// (two-ahead K prefetch ring). The PV phase retains the proven 2-D-tile grouped
+// structure -- exactly 4 V fragments live at any moment, two independent accumulator
+// chains (v_o[dt], v_o[dt+1]) per pair. v104/v105 REGRESSED by widening the D group;
+// we do NOT widen it again. The one-pair-ahead rescale of v106 is retained.
+//
+// What changed vs v106 (the ONLY change): the placement of the four current-pair V
+// loads relative to the next-pair rescale FMAs. v106 issued ALL FOUR V loads (va0,
+// va1, vb0, vb1) and THEN the 16 next-pair rescale FMAs, then the 4 WMMAs -- so the
+// rescale block sits as one contiguous 16-FMA VALU run after the last load is issued,
+// and the compiler must hold all four load destinations live across it. v107 SPLITS
+// the loads around the rescale: issue the two "a" V loads (va0, va1 -> v_o[dt] chain),
+// then the next-pair rescale FMAs, then the two "b" V loads (vb0, vb1 -> v_o[dt+1]
+// chain), then the 4 WMMAs.
+//
+// Rationale: the rescale FMAs now execute in the shadow of the FIRST pair of V loads'
+// memory latency while the SECOND pair is still being issued -- i.e. the VALU work
+// overlaps the load-issue window itself rather than waiting for all four loads to be
+// in flight. This shrinks the window in which all four V-load destinations are
+// simultaneously live (vb0/vb1 are produced AFTER the FMA block, so only va0/va1 are
+// live across the FMAs), which can ease the load-use s_waitcnt exposure that v106's
+// 4-loads-then-16-FMAs head still paid. Playbook lever 1 (separate memory-issuing
+// from VALU-only) + lever 2 (cross-pipe interleave), now interleaved at finer (half-
+// pair load) granularity.
+//
+// Arithmetic identical to v106: each v_o[dt] is rescaled EXACTLY ONCE before its PV
+// accumulation, same rescale value, same WMMA operand order -> bit-exact in bf16.
+// VGPR: same accumulators; live-V footprint is if anything slightly lower (vb loads
+// deferred past the FMAs) -> occupancy unchanged or better. RISK: low; if the compiler
+// already scheduled v106 this way it simply ties v106.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast107(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v107_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v107_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v107(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast107(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v107_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v107_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast107(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast107(v_s1[j]);
+
+        // ---- PV: v103's 2-D-tile grouped PV (4 live V fragments, two independent
+        // accumulator chains per pair) with the online rescale SOFTWARE-PIPELINED BY
+        // ONE PAIR. Prologue rescales pair 0; iteration dt then issues the current
+        // pair's 4 V loads, interleaves the NEXT pair's rescale (independent regs)
+        // between loads and WMMAs, and issues the current pair's 4 WMMAs. Each
+        // accumulator is rescaled exactly once before its PV WMMA -> bit-exact.
+        // DK=8 is even -> exact pairing, no remainder.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            // MID-LOAD split: issue the "a" V loads first, then the next-pair rescale
+            // FMAs (independent regs), then the "b" V loads, then the WMMAs. The rescale
+            // VALU thus overlaps the a-load latency while the b-loads are still issuing,
+            // and only va0/va1 are live across the FMA block.
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            // One-pair-ahead rescale: prepare the NEXT pair's accumulators while the
+            // current pair's "a" V loads are in flight. Independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast107(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v108.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v108.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v108_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v108<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v108_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v108_template.hpp
@@ -1,0 +1,237 @@
+// v108 -- v106 (best, 90.2 TFLOPS) + SPLIT next-pair PV rescale (2x 8-FMA chunks).
+//
+// Base choice: v106 (the running best). QK^T is BYTE-FOR-BYTE identical to v106
+// (two-ahead K prefetch ring). PV retains v106's proven 2-D-tile grouped structure --
+// exactly 4 V fragments live, two independent accumulator chains (v_o[dt], v_o[dt+1])
+// per pair, with the online rescale software-pipelined by ONE PAIR. v104/v105
+// REGRESSED by widening the D group; we do NOT widen it again. v107 tried a MID-LOAD
+// split (defer vb0/vb1 past the rescale) and REGRESSED to 85.27: deferring half the V
+// loads shortened the load-use distance for the "b" chain and exposed vmcnt waits.
+//
+// What changed vs v106 (the ONLY change): v106 issues all four V loads (va0,va1,vb0,
+// vb1), THEN the next pair's 16 rescale FMAs as one contiguous VALU block, THEN the 4
+// WMMAs. That 16-FMA run is a single long VALU dependency block sitting between the
+// loads and the matrix pipe; only its tail overlaps the first WMMA's issue window.
+//
+// v108 keeps v106's load ordering EXACTLY (all four V loads issued up front, both
+// chains retain full load-use distance -- the lesson of the v107 regression) but SPLITS
+// the 16 next-pair rescale FMAs into two 8-FMA chunks: the first 8 (v_o[dt+2]) issue
+// before the first WMMA pair, hiding under the V-load s_waitcnt latency; the second 8
+// (v_o[dt+3]) issue BETWEEN the two WMMA pairs, hiding in the first WMMA pair's issue
+// shadow. This spreads the VALU rescale across two latency windows instead of stacking
+// it as one block, attacking the same exposed-VALU stall v106 still pays at the head of
+// each pair -- without touching the V loads. Both chunks write DIFFERENT registers from
+// this pair's WMMAs, so there is no new false dependency.
+//
+// Arithmetic identical to v106: each v_o[dt] is rescaled EXACTLY ONCE before its PV
+// accumulation, same rescale value, same WMMA operand order -> bit-exact in bf16.
+// VGPR: same accumulators, same 4-live-V-fragment footprint as v106 -> occupancy
+// unchanged. RISK: low; if the compiler already scheduled v106 this way it ties v106.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast106(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v108_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v108_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v108(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast106(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v108_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v108_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast106(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast106(v_s1[j]);
+
+        // ---- PV: v106's 2-D-tile grouped PV (4 live V fragments, two independent
+        // accumulator chains per pair) with the online rescale SOFTWARE-PIPELINED BY
+        // ONE PAIR. Prologue rescales pair 0; iteration dt then issues the current
+        // pair's 4 V loads, then the NEXT pair's rescale (independent regs) SPLIT into
+        // two 8-FMA chunks placed around the WMMAs (v108), and issues the current pair's
+        // 4 WMMAs. Each accumulator is rescaled exactly once before its PV WMMA ->
+        // bit-exact. DK=8 is even -> exact pairing, no remainder.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale, SPLIT into two 8-FMA chunks (v108). All four V
+            // loads above stay in flight (v106 ordering -- both accumulator chains keep
+            // their full load-use distance). The next pair's 16 rescale FMAs are split:
+            // the first 8 (v_o[dt+2]) overlap the V-load s_waitcnt latency before the
+            // first WMMA; the second 8 (v_o[dt+3]) overlap the issue window of the first
+            // WMMA pair. Both chunks touch DIFFERENT registers from this pair's WMMAs.
+            const bool resc_next = (dt + 2 < DK) && need_rescale;
+            if (resc_next) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            if (resc_next) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast106(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v109.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v109.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v109_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v109<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v109_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v109_template.hpp
@@ -1,0 +1,247 @@
+// v109 -- v106 (best, 90.2 TFLOPS) + ONE-PAIR-AHEAD SOFTWARE-PIPELINED PV V-PREFETCH.
+//
+// Base choice: v106 (the running best). QK^T is kept BYTE-FOR-BYTE identical to v106
+// (two-ahead K prefetch ring), and v106's proven online-rescale schedule (prologue
+// rescales pair 0; iteration dt rescales the NEXT pair's accumulators before its WMMAs)
+// is preserved BYTE-FOR-BYTE. The PV phase retains v106's 2-D-tile grouped structure
+// (4 V fragments live, two independent accumulator chains per pair).
+//
+// WHY the rescale-placement knob is exhausted: v106 (all 16 rescale FMAs BEFORE the
+// contiguous 4-WMMA quartet) = 90.2; v108 (8 before + 8 between the two WMMA pairs) =
+// 88.65. More pre-WMMA filler wins, and v106 already places ALL of it before a dense
+// quartet. Redistributing those FMAs (the 12/4 split) only re-fragments matrix-pipe
+// cadence -> lands between v108 and v106. So we stop tuning rescale placement.
+//
+// What changed vs v106 (the ONLY change): the PV phase now PREFETCHES the next pair's
+// 4 V fragments one iteration ahead (a 1-pair V ring). v106 loads all 4 V frags at the
+// head of each pair's iteration and immediately consumes them in the WMMA quartet ->
+// load-use distance ~= 0. Those loads are only hidden when need_rescale==true (the
+// rescale FMAs fill the shadow). But late in the KV loop the running max stabilizes and
+// need_rescale becomes FALSE on most iterations -- then the PV V-loads are FULLY EXPOSED
+// and the matrix pipe stalls on vmcnt at every pair head. v109 hoists the next pair's
+// V loads to issue BEFORE the current pair's WMMAs, so each WMMA quartet consumes V
+// fragments that were fetched a full pair ago: the global-load latency overlaps the
+// previous quartet's matrix-pipe issue window regardless of need_rescale. This is
+// playbook lever 3 ("V software-pipelining in the PV phase, mirroring the K pipeline,
+// +1-3 TFLOPS") -- COMPLEMENTARY to v106's rescale schedule, not competing with it.
+//
+// Arithmetic identical to v106: V fragments are byte-for-byte the same values, just
+// loaded earlier; each v_o[dt] is rescaled EXACTLY ONCE before its PV accumulation,
+// same rescale value, same WMMA operand order -> bit-exact in bf16. VGPR: +4 live bf16x8
+// fragments for the next-pair ring (the current AND next pair's V are live across the
+// WMMAs) -- a modest bump; if it costs a wave it should still net positive since the
+// exposed-load stall it removes is on the common-case path. RISK: low-med (the extra
+// V-fragment liveness; watch the 256-VGPR / 7-wave ceiling).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast106(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v109_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v109_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v109(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast106(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v109_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v109_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast106(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast106(v_s1[j]);
+
+        // ---- PV: v106's 2-D-tile grouped PV (two independent accumulator chains per
+        // pair) + v106's one-pair-ahead rescale schedule (byte-for-byte) + a NEW 1-pair
+        // V-prefetch ring so each WMMA quartet consumes V fetched a full pair earlier.
+        // Each accumulator is rescaled exactly once before its PV WMMA -> bit-exact.
+        // DK=8 is even -> exact pairing, no remainder.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        // 1-PAIR V RING: preload pair 0's 4 fragments before the loop. The loop body then
+        // prefetches the NEXT pair before issuing the CURRENT pair's WMMAs, so every WMMA
+        // quartet consumes V fetched a full pair earlier -- the global-load latency hides
+        // in the previous quartet's matrix-pipe issue window, independent of need_rescale.
+        bf16x8_t cur_va0 = *reinterpret_cast<const bf16x8_t*>(VTp + (0 * W_K + col16) * vt_stride_d + n_base + row8);
+        bf16x8_t cur_va1 = *reinterpret_cast<const bf16x8_t*>(VTp + (0 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+        bf16x8_t cur_vb0 = *reinterpret_cast<const bf16x8_t*>(VTp + (1 * W_K + col16) * vt_stride_d + n_base + row8);
+        bf16x8_t cur_vb1 = *reinterpret_cast<const bf16x8_t*>(VTp + (1 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            // Prefetch the NEXT pair's 4 V fragments (issue ahead of the current WMMAs).
+            bf16x8_t nxt_va0, nxt_va1, nxt_vb0, nxt_vb1;
+            if (dt + 2 < DK) {
+                const int np  = dt + 2;
+                const int np1 = dt + 3;
+                nxt_va0 = *reinterpret_cast<const bf16x8_t*>(VTp + (np  * W_K + col16) * vt_stride_d + n_base + row8);
+                nxt_va1 = *reinterpret_cast<const bf16x8_t*>(VTp + (np  * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+                nxt_vb0 = *reinterpret_cast<const bf16x8_t*>(VTp + (np1 * W_K + col16) * vt_stride_d + n_base + row8);
+                nxt_vb1 = *reinterpret_cast<const bf16x8_t*>(VTp + (np1 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+            }
+            // v106 rescale schedule, byte-for-byte: prepare the NEXT pair's accumulators
+            // while the next pair's V loads are in flight. Independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            // Current pair WMMAs consume V fetched a pair ago (cur_* == v106's va0/va1/vb0/vb1).
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(cur_va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(cur_vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(cur_va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(cur_vb1, v_p1, v_o[dt1]);
+            // Advance the ring (compile-time register rename under full unroll).
+            cur_va0 = nxt_va0; cur_va1 = nxt_va1;
+            cur_vb0 = nxt_vb0; cur_vb1 = nxt_vb1;
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast106(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v110.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v110.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v110_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v110<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v110_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v110_template.hpp
@@ -1,0 +1,252 @@
+// v110 -- v106 (frontier, ~90.2 TFLOPS) + MINIMAL TWO-FRAGMENT V PREFETCH.
+//
+// Base choice: v106 (the running best). QK^T, softmax, the prologue pair-0 rescale,
+// and the one-pair-ahead rescale schedule are kept BYTE-FOR-BYTE identical to v106.
+// The ONLY change is in the PV WMMA loop's V-load scheduling.
+//
+// Why v109 failed (round 10) and why this is different:
+//   v109 carried a FULL 1-pair ring -- all FOUR next V fragments (cur_va0/va1/vb0/vb1
+//   + nxt_*) live across the WMMA quartet. That +4 live bf16x8 V-fragment pressure on
+//   top of v_o[8], v_q[DK], and the packed probabilities pushed the kernel over an
+//   occupancy/allocation cliff (90.2 -> 85.12). v109 also left the final-iteration
+//   `cur = nxt` assignment reading uninitialized `nxt_*` (dead, but UB-shaped codegen).
+//
+// v110's middle ground (reviewer-sanctioned next lever):
+//   Carry ONLY the "a" chain's two fragments (cur_va0, cur_va1 -- the operands of the
+//   v_o[dt] accumulator chain) ONE pair-iteration ahead. The "b" chain's fragments
+//   (vb0, vb1, feeding v_o[dt1]) are loaded JUST-IN-TIME inside the iteration, exactly
+//   as v106 loads them. Net steady-state liveness is +2 V fragments over v106 (the one
+//   carried pair), HALF of v109's +4 -- well short of the cliff.
+//
+//   The carried cur_va0/cur_va1 are issued a full pair-iteration before they are
+//   consumed: their load happens at the END of iteration dt-2 (the `nxt_va*` prefetch),
+//   so it is in flight across iteration dt-2's rescale FMAs AND its 4 PV WMMAs before
+//   iteration dt's first WMMA needs it. That is real load-use distance for the "a"
+//   chain WITHOUT a 4-wide ring. The "b" chain still consumes JIT loads, but its WMMAs
+//   are issued AFTER the "a" chain's two WMMAs, giving them natural in-quartet spacing.
+//
+//   The next-pair rescale (v106's schedule) is left exactly where v106 puts it -- in the
+//   shadow of the in-flight prefetch loads -- so the rescale FMAs still overlap memory.
+//
+// Correctness: the WMMA operand order and rescale-once-per-accumulator semantics are
+//   IDENTICAL to v106 (cur_va0==v106 va0, vb0==vb0, cur_va1==va1, vb1==vb1; same v_p0/
+//   v_p1 pairing; same accumulator chain). -> bit-exact in bf16. The ring advance is
+//   GUARDED by `if (dt + 2 < DK)` so the final iteration performs NO uninitialized
+//   assignment (fixes the v109 UB-shaped tail). DK=8 even -> exact pairing, no remainder.
+//
+// RISK: low. If the compiler already scheduled v106's "a"-chain loads early, v110 ties
+//   v106; the +2 liveness is small enough that an occupancy regression is unlikely.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast110(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v110_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v110_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v110(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast110(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103/v106, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v110_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v110_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast110(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast110(v_s1[j]);
+
+        // ---- PV: v106's 2-D-tile grouped PV (two independent accumulator chains per
+        // pair) + v106's one-pair-ahead rescale schedule, with a MINIMAL TWO-FRAGMENT
+        // V prefetch on the "a" chain only. The "a" fragments (cur_va0/cur_va1, operands
+        // of v_o[dt]) are carried one pair-iteration ahead; the "b" fragments (vb0/vb1,
+        // operands of v_o[dt1]) are loaded just-in-time as in v106. +2 live V fragments
+        // vs v106, half of v109's +4. WMMA operand order identical to v106 -> bit-exact.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        // Preload pair 0's "a" fragments (operands of the v_o[0] chain).
+        bf16x8_t cur_va0 = *reinterpret_cast<const bf16x8_t*>(VTp + (0 * W_K + col16) * vt_stride_d + n_base + row8);
+        bf16x8_t cur_va1 = *reinterpret_cast<const bf16x8_t*>(VTp + (0 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            // JIT-load the current pair's "b" fragments (operands of v_o[dt1]).
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+            // TWO-FRAGMENT PREFETCH: issue the NEXT pair's "a" fragments now, so they are
+            // in flight across this iteration's rescale FMAs and 4 WMMAs.
+            bf16x8_t nxt_va0, nxt_va1;
+            if (dt + 2 < DK) {
+                const int np = dt + 2;
+                nxt_va0 = *reinterpret_cast<const bf16x8_t*>(VTp + (np * W_K + col16) * vt_stride_d + n_base + row8);
+                nxt_va1 = *reinterpret_cast<const bf16x8_t*>(VTp + (np * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+            }
+            // v106 rescale schedule, byte-for-byte: next pair's accumulators in the shadow
+            // of the in-flight V loads. Independent regs -> independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            // Current pair WMMAs. "a" operands prefetched a pair ago; "b" operands JIT.
+            // Operand order identical to v106 (va0/p0, vb0/p0, va1/p1, vb1/p1).
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(cur_va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0,     v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(cur_va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1,     v_p1, v_o[dt1]);
+            // Advance the 2-fragment ring ONLY when a next pair exists -> no dead
+            // uninitialized assignment on the final iteration (fixes v109's UB tail).
+            if (dt + 2 < DK) {
+                cur_va0 = nxt_va0;
+                cur_va1 = nxt_va1;
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast110(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v111.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v111.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v111_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v111<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v111_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v111_template.hpp
@@ -1,0 +1,216 @@
+// v111 -- v100 + bit-exact BALANCED-TREE softmax max-reduction (zero-register change).
+//
+// Base: v100 (the measured champion @ ~89.4-90.45 TFLOPS). Every later attempt
+// (v101-v110) failed to clear the gate. The decisive lesson from v109/v110 is that
+// ANY change adding register liveness across the PV phase (where the fp32x8 O
+// accumulator pressure peaks at ~205 VGPR / 7 waves) tips an occupancy/allocation
+// cliff and REGRESSES (v109 -5, v110 ~tie/-). So the only safe lever left is one with
+// ZERO added register cost.
+//
+// THE EXPOSED CHAIN: between the QK^T WMMAs (produce v_s0/v_s1) and the PV WMMAs, the
+// kernel must compute row_max, because the PV operand v_p = bf16(exp2(s - new_m))
+// depends on new_m = max(m_row, row_max). v100 computes row_max with a STRICTLY SERIAL
+// fmax chain over 16 values:
+//     row_max = v_s0[0]; for j: row_max = fmax(row_max, v_s0[j]); for j: fmax(.., v_s1[j]);
+// That is a ~15-deep dependency chain. The compiler is NOT allowed to reassociate
+// fmax of floats without -ffast-math (the build uses plain -O3), so this serial chain
+// survives to the ISA and sits exposed on the QK->softmax->PV critical path, stalling
+// the matrix pipe between the two WMMA phases.
+//
+// THE CHANGE (only this block differs from v100): replace the serial chain with a
+// balanced pairwise tree of depth 4:
+//   t[j] = fmax(v_s0[j], v_s1[j])   (8 independent fmax, depth 1)
+//   then reduce the 8 lane-local partials 8->4->2->1 (depths 2-4).
+// This shortens the exposed reduction latency from ~15 to ~4 dependent fmax ops with
+// ZERO extra live registers (t[] is consumed immediately; v_s0/v_s1 were already live).
+//
+// BIT-EXACTNESS: fmax over a fixed set of finite values is fully associative and
+// commutative -- it merely SELECTS the maximum element, it never rounds. So the tree
+// yields the byte-identical row_max as v100's serial chain for every input. The
+// cross-half fold (v111_cross_half_max) and everything downstream (new_m, rescale,
+// exp2, the serial row_sum, bf16 pack, both WMMA phases, K-prefetch ring) are
+// byte-for-byte v100. The row_sum reduction is left SERIAL and identical to v100
+// (it is off the PV critical path -- l_row is consumed only after the KV loop -- so
+// there is no reason to perturb its arithmetic). Result: n_bad(>0.05)=0, bit-exact.
+//
+// VGPR: identical to v100 (~205, 7 waves/SIMD). No LDS, no barriers, no new buffers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast111(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v111_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v111_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v111(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast111(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // ---- Softmax row max over 16 values (8 from s0, 8 from s1).
+        // BALANCED TREE (depth 4) instead of v100's serial ~15-deep fmax chain.
+        // fmax is associative+commutative for finite values -> selects the same
+        // maximum element -> byte-identical row_max as v100, but on a far shorter
+        // dependency chain that no longer stalls the QK->PV transition. Zero extra
+        // live registers (t[] is consumed immediately).
+        fp32_t t[8];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) t[j] = __builtin_fmaxf(v_s0[j], v_s1[j]); // depth 1
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) t[j] = __builtin_fmaxf(t[j], t[j + 4]);   // depth 2
+        t[0] = __builtin_fmaxf(t[0], t[2]);                                    // depth 3
+        t[1] = __builtin_fmaxf(t[1], t[3]);
+        fp32_t row_max = __builtin_fmaxf(t[0], t[1]);                          // depth 4
+        row_max = v111_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        // row_sum: kept SERIAL and byte-for-byte identical to v100 (off the PV
+        // critical path -- l_row is consumed only after the KV loop).
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v111_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast111(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast111(v_s1[j]);
+
+        // ---- PV: two WMMAs per D-tile, rescale fused per D-tile (v39/v100 structure).
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast111(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v112.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v112.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v112_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v112<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v112_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v112_template.hpp
@@ -1,0 +1,243 @@
+// v112 -- v106 (MEASURED champion, 90.20 TFLOPS) + BALANCED-TREE softmax row_max.
+//
+// Base choice: v106 (the running best, measured 90.20 @ b4h32n4096). v106 = v103's
+// two-ahead QK K-prefetch ring + 2-D-tile grouped PV (4 live V fragments, two
+// independent accumulator chains per pair) + one-pair-ahead software-pipelined rescale.
+// PV restructuring is now SATURATED on this box: v104/v105 (4-chain) regressed hard,
+// v109/v110 (V-prefetch rings) dipped below v106, v102 (all-8 batched rescale) starved
+// the matrix pipe. So v112 leaves the entire QK^T + PV schedule of v106 BYTE-FOR-BYTE
+// untouched and attacks the OTHER component the round-7 reviewer named as part of the
+// remaining mixed limit: the softmax cost wedged on the QK->PV critical path.
+//
+// THE ONE CHANGE: replace the softmax row-max reduction's SERIAL fmax chain with a
+// BALANCED TREE (depth 4 instead of ~15). v106 inherits v39/v100's reduction:
+//     row_max = fmax(s0[0], s0[1]); ... fold s0[2..7] then s1[0..7]  -> a 15-deep
+// serial fmax dependency chain. That chain sits directly between the QK^T WMMAs (which
+// produce v_s0/v_s1) and the cross-half ds_bpermute + exp2 + PV -- i.e. on the exposed
+// QK->PV transition where neither the QK nor the PV matrix pipe is running. Shortening
+// it from depth ~15 to depth 4 (3 levels of pairwise fmax over the 8 t[] partials, then
+// the 2-2-1 fold) collapses ~11 serial-dependent VALU latencies off that transition.
+//
+// Why it should surface HERE when it did NOT on v100: v111 applied the same tree to the
+// v100 base (single-chain PV) and only tied/dipped (88.74) because v100's slow PV phase
+// dominated and hid the softmax chain. v106's grouped+pipelined PV is ~2 TFLOPS faster,
+// so the softmax/transition latency is now a larger fraction of the iteration -- exactly
+// where shortening its dependency chain can pay off. Orthogonal to every PV lever tried.
+//
+// BIT-EXACTNESS: fmax is associative and commutative for finite values, so a balanced
+// tree selects the SAME maximum element as the serial chain -> byte-identical row_max,
+// hence byte-identical new_m / rescale / exp2 args / probs / O. (The QK^T scores here
+// are always finite -- no masking in this kernel.) row_sum is left SERIAL and identical
+// to v106 (it is off the PV critical path: l_row is consumed only after the KV loop).
+// VGPR: t[8] is consumed immediately within the reduction, zero net new live state ->
+// same accumulators, same 4-live-V-fragment footprint as v106 -> occupancy unchanged.
+// RISK: low. If the compiler already tree-balanced v106's fmax chain, v112 ties v106.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast112(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v112_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v112_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v112(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast112(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax row max over 16 values (8 from s0, 8 from s1).
+        // BALANCED TREE (depth 4) instead of v106's serial ~15-deep fmax chain.
+        // fmax is associative+commutative for finite values -> selects the same
+        // maximum element -> byte-identical row_max as v106, but on a far shorter
+        // dependency chain that no longer stalls the exposed QK->PV transition.
+        // t[] is consumed immediately -> zero extra live registers.
+        fp32_t t[8];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) t[j] = __builtin_fmaxf(v_s0[j], v_s1[j]); // depth 1
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) t[j] = __builtin_fmaxf(t[j], t[j + 4]);   // depth 2
+        t[0] = __builtin_fmaxf(t[0], t[2]);                                    // depth 3
+        t[1] = __builtin_fmaxf(t[1], t[3]);
+        fp32_t row_max = __builtin_fmaxf(t[0], t[1]);                          // depth 4
+        row_max = v112_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v112_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast112(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast112(v_s1[j]);
+
+        // ---- PV: v103's 2-D-tile grouped PV (4 live V fragments, two independent
+        // accumulator chains per pair) with the online rescale SOFTWARE-PIPELINED BY
+        // ONE PAIR. Prologue rescales pair 0; iteration dt then issues the current
+        // pair's 4 V loads, interleaves the NEXT pair's rescale (independent regs)
+        // between loads and WMMAs, and issues the current pair's 4 WMMAs. Each
+        // accumulator is rescaled exactly once before its PV WMMA -> bit-exact.
+        // DK=8 is even -> exact pairing, no remainder.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale: prepare the NEXT pair's accumulators while the
+            // current pair's V loads are in flight. Independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast112(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v113.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v113.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v113_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v113<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v113_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v113_template.hpp
@@ -1,0 +1,261 @@
+// v113 -- v106 (MEASURED champion, 90.20 TFLOPS) + TWO bit-exact critical-path shorteners
+//         on the exposed QK->PV softmax transition: (1) balanced-tree row_max and
+//         (2) PACK-BEFORE-SUM reorder.
+//
+// Base choice: v106 (the running best, measured 90.20 @ b4h32n4096). v106 = v103's
+// two-ahead QK K-prefetch ring + 2-D-tile grouped PV (4 live V fragments, two
+// independent accumulator chains per pair) + one-pair-ahead software-pipelined rescale.
+// PV restructuring is now SATURATED on this box: v104/v105 (4-chain) regressed hard,
+// v107/v108 (rescale placement) regressed, v109/v110 (V-prefetch rings) dipped below
+// v106, v102 (all-8 batched rescale) starved the matrix pipe. So v113 leaves the entire
+// QK^T + PV WMMA schedule of v106 BYTE-FOR-BYTE untouched and attacks the OTHER
+// component the round-7 reviewer named as the remaining mixed limit: the softmax cost
+// wedged on the exposed QK->PV transition (where neither matrix pipe is running).
+//
+// CHANGE 1 -- balanced-tree row_max (depth 4 vs ~15 serial). v106 inherits v39/v100's
+// reduction: a 15-deep serial fmax dependency chain sitting directly between the QK^T
+// WMMAs (produce v_s0/v_s1) and the cross-half ds_bpermute + exp2 + PV. Shortening it
+// to depth 4 collapses ~11 serial-dependent VALU latencies off the transition.
+//
+// CHANGE 2 -- PACK-BEFORE-SUM reorder. In v106 the ~15-deep SERIAL row_sum chain is
+// emitted in program order BETWEEN exp2 and the bf16 pack that produces PV's B-operand
+// (v_p0/v_p1). But l_row (the sum) is consumed only AFTER the whole KV loop -- it is OFF
+// the QK->PV critical path. v113 emits the pack FIRST, then the sum. This shortens the
+// exposed exp2->(PV operand) program-order distance so the matrix pipe can begin PV
+// sooner, while the off-critical-path sum retires in the WMMA issue shadow. Pack and sum
+// both only READ v_s and write disjoint outputs -> no data dependency -> pure reorder.
+//
+// Both changes target the SAME unsolved bottleneck (the softmax wedge) from two angles
+// and are mutually orthogonal; together they should shorten the exposed transition more
+// than the tree alone (v112). v111 applied only the tree to the slower v100 PV and merely
+// tied (88.74) because v100's PV dominated; v106's faster PV makes the transition a larger
+// fraction of the iteration, so shortening it can finally surface. Orthogonal to all PV
+// levers tried.
+//
+// BIT-EXACTNESS: fmax is associative+commutative for finite values, so the balanced tree
+// selects the SAME maximum element as the serial chain -> byte-identical row_max, hence
+// byte-identical new_m / rescale / exp2 args / probs / O. (QK^T scores are always finite
+// -- no masking.) The pack/sum reorder changes neither operand: v_p comes from the same
+// bf16_fast113(v_s) values, l_row from the same serial-order sum -> byte-identical.
+// VGPR: t[8] consumed immediately, pack/sum use the same live regs -> zero net new live
+// state -> same 4-live-V-fragment footprint as v106 -> occupancy unchanged.
+// RISK: low. If the compiler already schedules v106 this way, v113 ties v106.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast113(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v113_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v113_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v113(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast113(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax row max over 16 values (8 from s0, 8 from s1).
+        // BALANCED TREE (depth 4) instead of v106's serial ~15-deep fmax chain.
+        // fmax is associative+commutative for finite values -> selects the same
+        // maximum element -> byte-identical row_max as v106, but on a far shorter
+        // dependency chain that no longer stalls the exposed QK->PV transition.
+        // t[] is consumed immediately -> zero extra live registers.
+        fp32_t t[8];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) t[j] = __builtin_fmaxf(v_s0[j], v_s1[j]); // depth 1
+        #pragma unroll
+        for (int j = 0; j < 4; ++j) t[j] = __builtin_fmaxf(t[j], t[j + 4]);   // depth 2
+        t[0] = __builtin_fmaxf(t[0], t[2]);                                    // depth 3
+        t[1] = __builtin_fmaxf(t[1], t[3]);
+        fp32_t row_max = __builtin_fmaxf(t[0], t[1]);                          // depth 4
+        row_max = v113_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        // PACK-BEFORE-SUM reorder: emit the bf16 pack of the PV operands (v_p0/v_p1)
+        // BEFORE the serial row_sum reduction. In v106/v112 the serial row_sum chain
+        // sits in program order between exp2 and the pack that produces PV's B-operand
+        // -- yet l_row (the sum) is consumed only AFTER the whole KV loop, so it is OFF
+        // the QK->PV critical path. Hoisting the pack ahead of the sum shortens the
+        // exposed program-order distance from exp2 (which produces v_s0/v_s1) to the
+        // first PV WMMA operand, letting the matrix pipe start PV sooner while the
+        // off-critical-path sum retires in the WMMA issue shadow. Pack reads v_s, sum
+        // reads v_s, neither writes the other's input -> no data dependency between
+        // them -> reordering is byte-identical (same v_p, same l_row).
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast113(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast113(v_s1[j]);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v113_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        // ---- PV: v103's 2-D-tile grouped PV (4 live V fragments, two independent
+        // accumulator chains per pair) with the online rescale SOFTWARE-PIPELINED BY
+        // ONE PAIR. Prologue rescales pair 0; iteration dt then issues the current
+        // pair's 4 V loads, interleaves the NEXT pair's rescale (independent regs)
+        // between loads and WMMAs, and issues the current pair's 4 WMMAs. Each
+        // accumulator is rescaled exactly once before its PV WMMA -> bit-exact.
+        // DK=8 is even -> exact pairing, no remainder.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale: prepare the NEXT pair's accumulators while the
+            // current pair's V loads are in flight. Independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast113(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v114.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v114.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v114_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v114<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v114_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v114_template.hpp
@@ -1,0 +1,272 @@
+// v114 -- v106 (MEASURED champion, 90.20 TFLOPS) + CROSS-PIPE exp2/pack INTERLEAVE of
+//         subtile 1 into the matrix-pipe shadow of pair-0's first two PV WMMAs (v45 lever).
+//
+// Base choice: v106, the measured best @ b4h32n4096. QK^T (two-ahead K prefetch ring) and
+// the ENTIRE PV WMMA cadence + accumulator chaining + one-pair-ahead rescale are kept
+// BYTE-FOR-BYTE. PV restructuring is saturated on this box (v104/v105 4-chain regressed,
+// v107/v108 rescale-placement regressed, v109/v110 V-prefetch rings dipped below v106), so
+// v114 does NOT touch the PV schedule. Instead it attacks the SAME unsolved softmax wedge
+// the reviewer named, but with the one playbook lever never yet implemented: lever 2 / v45
+// CROSS-PIPE INTERLEAVE -- hide the transcendental exp2 in the WMMA issue shadow.
+//
+// THE ONLY CHANGE (cross-pipe interleave of subtile 1):
+//   In v106 the softmax does, in program order: exp2(s0)+exp2(s1) -> row_sum -> pack
+//   v_p0(from s0)+pack v_p1(from s1) -> prologue rescale -> PV loop. The first PV WMMA
+//   thus waits for BOTH subtiles' 16 exp2 transcendentals to retire even though pair-0's
+//   first two WMMAs consume ONLY v_p0 (= exp2(s0)). The exp2 on subtile 1 (8 transcendentals
+//   on the exp pipe) sits needlessly on the path to the matrix pipe starting work.
+//
+//   v114 peels pair 0 out of the PV loop and reorders so subtile-1's exp2+pack run in the
+//   shadow of pair-0's first two PV WMMAs:
+//     1. exp2(s0); pack v_p0.                              (path to first WMMA)
+//     2. prologue rescale pair 0.
+//     3. load pair-0 V (va0/va1/vb0/vb1); rescale pair 2 ahead (v106's dt=0 body verbatim).
+//     4. WMMA(va0,v_p0,o0); WMMA(vb0,v_p0,o1).             <- matrix pipe runs on v_p0 only
+//     5. exp2(s1); pack v_p1.                              <- exp pipe runs UNDER step 4
+//     6. WMMA(va1,v_p1,o0); WMMA(vb1,v_p1,o1).             <- pair-0 completes (v106 order)
+//     7. row_sum (off the QK->PV critical path; l_row consumed only after the KV loop).
+//     8. PV loop for pairs dt=2,4,6 -- v106's body VERBATIM.
+//   The 8 exp2(s1) transcendentals now co-execute with two bf16 WMMAs (~12.6-cyc issue
+//   window each) instead of blocking the matrix pipe's start. Playbook: exp2 partially
+//   co-executes with wmma; ~0.4 cyc exp hides per bf16 WMMA.
+//
+// BIT-EXACT: exp2 args (new_m), the bf16 RNE pack, the serial row_sum order, the rescale
+// value, and the per-accumulator WMMA operand order (o0: va0*p0 then va1*p1; o1: vb0*p0 then
+// vb1*p1) are ALL identical to v106 -> byte-identical row_max/new_m/probs/l_row/O.
+// VGPR: no new accumulators or V fragments; v_s1 stays live across two extra WMMAs and
+// v_p1 is produced later -> net live state ~unchanged -> same 4-live-V-fragment footprint
+// and occupancy as v106. RISK: low. If the compiler already hoisted v106's WMMAs above
+// exp2(s1), v114 simply ties v106.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast114(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v114_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v114_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v114(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast114(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v114_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        // exp2 of SUBTILE 0 ONLY (the path to pair-0's first two PV WMMAs, which consume
+        // v_p0 only). Subtile-1 exp2 + pack + row_sum are DEFERRED below into the
+        // matrix-pipe shadow of those two WMMAs (cross-pipe interleave, playbook lever 2).
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast114(v_s0[j]);
+
+        // ---- PV: v106's 2-D-tile grouped PV, one-pair-ahead pipelined rescale, with
+        // PAIR 0 PEELED so subtile-1's exp2/pack/row_sum run UNDER pair-0's first two
+        // WMMAs. Prologue rescales pair 0 (v106 verbatim).
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+
+        // ---- PEELED PAIR 0 (cross-pipe interleave) ----
+        {
+            const bf16_t* a0 = VTp + (0 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (0 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale of pair 2 (v106's dt=0 body, identical guard/order).
+            if (DK > 2 && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[3][j] *= rescale;
+            }
+            // First two WMMAs consume ONLY v_p0 -> matrix pipe starts BEFORE exp2(s1).
+            v_o[0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[0]);
+            v_o[1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[1]);
+
+            // CROSS-PIPE: subtile-1 exp2 (8 transcendentals) + pack now execute on the
+            // exp/VALU pipe in the shadow of the two WMMAs above. row_sum (off the
+            // QK->PV critical path -- l_row consumed only after the KV loop) follows.
+            // Bit-exact: same exp2 args, same RNE pack, same serial s0-then-s1 sum order.
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast114(v_s1[j]);
+
+            fp32_t row_sum = v_s0[0];
+            #pragma unroll
+            for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+            row_sum = v114_cross_half_sum(row_sum);
+            l_row += row_sum;
+
+            // pair-0 completes with v_p1 (same per-accumulator WMMA order as v106).
+            v_o[0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[0]);
+            v_o[1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[1]);
+        }
+
+        // ---- Remaining pairs dt=2,4,6: v106 PV body VERBATIM ----
+        #pragma unroll
+        for (int dt = 2; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale: prepare the NEXT pair's accumulators while the
+            // current pair's V loads are in flight. Independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast114(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v115.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v115.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v115_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v115<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v115_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v115_template.hpp
@@ -1,0 +1,259 @@
+// v115 -- v106 champion (90.20 TFLOPS) + 3-WIDE PV GROUPING (three independent
+// accumulator chains, <=6 live V fragments) with the rescale software-pipelined ONE
+// GROUP AHEAD.
+//
+// Base: v106 (the MEASURED running best, 90.20 TFLOPS). QK^T is BYTE-FOR-BYTE identical
+// to v106 (two-ahead K prefetch ring). The softmax/exp2/pack path is identical. The
+// ONLY change is the PV-phase grouping width.
+//
+// Why 3-wide (reviewer's explicit NEXT FOCUS for this round):
+//   v106 uses 2-wide PV groups -> TWO independent accumulator chains (v_o[dt], v_o[dt+1]).
+//   Within a pair, the two dependent WMMAs on the SAME accumulator (p0 then p1) are
+//   separated by only ONE independent WMMA (the other chain's p0). On RDNA4 the WMMA
+//   result latency wants ~2 independent issues of cover, so v106 still leaves a small
+//   bubble on each accumulator's second WMMA.
+//   v104 (4-wide, 8 live V frags) and v105 (4-wide two-wave JIT) BOTH REGRESSED hard
+//   (~79 TFLOPS) -- 8 live V fragments blew the VGPR/scheduling budget (the reviewer's
+//   diagnosed "VGPR cliff"). 3-wide is the sweet spot the reviewer asked for:
+//     * THREE independent chains -> the second WMMA on each accumulator is now separated
+//       by TWO independent WMMAs (the other two chains' p0) -> full result-latency cover.
+//     * exactly 6 live V fragments (3x p0-col + 3x p1-col) -- the reviewer's stated <=6
+//       ceiling, ~+8 VGPR over v106's 4 (197 -> ~205, still the 7-wave band v39 ran at),
+//       NOT v104's 8-fragment cliff.
+//
+// Grouping: DK=8 -> groups {0,1,2},{3,4,5},{6,7} (last group is a 2-wide remainder,
+// exactly v106's pair). Rescale is pipelined ONE GROUP ahead exactly as v106 pipelined
+// one PAIR ahead: a prologue rescales group 0; iteration over group g issues that
+// group's V loads, then interleaves the NEXT group's rescale (DIFFERENT, independent
+// accumulator regs) before issuing the current group's WMMAs (all p0 then all p1).
+//
+// Arithmetic: each v_o[i] is rescaled EXACTLY ONCE before its PV accumulation, with the
+// same rescale scalar, and each accumulator's own WMMA order is unchanged (its p0
+// contribution then its p1 contribution -- identical to v106). Only the interleaving
+// ACROSS independent accumulators changes, which does not alter any single accumulator's
+// fp32 sum -> bit-exact / n_bad==0, same as v106.
+// RISK: low-med. The +8 live-V VGPR may tip occupancy on a bad allocation; if so this
+// ties or slightly trails v106. No correctness risk.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast115(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v115_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v115_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v115(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast115(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v115_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v115_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast115(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast115(v_s1[j]);
+
+        // ---- PV: 3-WIDE grouped PV (THREE independent accumulator chains, <=6 live V
+        // fragments) with the online rescale SOFTWARE-PIPELINED BY ONE GROUP.
+        // Groups of GW=3 D-tiles: {0,1,2},{3,4,5},{6,7} for DK=8. Within a group we
+        // load all V fragments (p0-col + p1-col = up to 6 frags), interleave the NEXT
+        // group's rescale (independent accumulator regs), then issue all p0 WMMAs
+        // followed by all p1 WMMAs. Each accumulator's own WMMA order (its p0 then its
+        // p1 contribution) is identical to v106 -> bit-exact. Three chains separate the
+        // two dependent WMMAs on each accumulator by TWO independent WMMAs -> full
+        // result-latency cover (v106's pairs gave only one).
+        constexpr int GW = 3;
+        if (need_rescale) {
+            #pragma unroll
+            for (int i = 0; i < (GW < DK ? GW : DK); ++i) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[i][j] *= rescale;
+            }
+        }
+        #pragma unroll
+        for (int g0 = 0; g0 < DK; g0 += GW) {
+            const int gsz = (DK - g0 < GW) ? (DK - g0) : GW;
+            bf16x8_t va[GW];  // p0-column V fragments (paired with v_p0)
+            bf16x8_t vb[GW];  // p1-column V fragments (paired with v_p1)
+            #pragma unroll
+            for (int i = 0; i < GW; ++i) {
+                if (i < gsz) {
+                    const int dt = g0 + i;
+                    const bf16_t* pa = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                    const bf16_t* pb = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                    va[i] = *reinterpret_cast<const bf16x8_t*>(pa);
+                    vb[i] = *reinterpret_cast<const bf16x8_t*>(pb);
+                }
+            }
+            // One-group-ahead rescale: prepare the NEXT group's accumulators (different,
+            // independent regs) while the current group's V loads are in flight.
+            if (need_rescale) {
+                #pragma unroll
+                for (int i = 0; i < GW; ++i) {
+                    const int nd = g0 + GW + i;
+                    if (nd < DK) {
+                        #pragma unroll
+                        for (int j = 0; j < 8; ++j) v_o[nd][j] *= rescale;
+                    }
+                }
+            }
+            #pragma unroll
+            for (int i = 0; i < GW; ++i) {
+                if (i < gsz) {
+                    const int dt = g0 + i;
+                    v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va[i], v_p0, v_o[dt]);
+                }
+            }
+            #pragma unroll
+            for (int i = 0; i < GW; ++i) {
+                if (i < gsz) {
+                    const int dt = g0 + i;
+                    v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb[i], v_p1, v_o[dt]);
+                }
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast115(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v116.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v116.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v116_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v116<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v116_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v116_template.hpp
@@ -1,0 +1,269 @@
+// v116 -- v106 (MEASURED champion, 90.20 TFLOPS) + CROSS-KV-TILE K PREFETCH (n_pipe=2 at
+//          KV-block granularity, bounded to the first D-tile pair so occupancy is preserved).
+//
+// Base choice: v106 (running best, measured 90.20 @ b4h32n4096). v106 = v103's two-ahead
+// intra-tile QK^T K-prefetch ring + 2-D-tile grouped PV (4 live V fragments, two
+// independent accumulator chains per pair) + one-pair-ahead software-pipelined rescale.
+// PV restructuring is SATURATED on this box (v104/v105 4-chain regressed, v107/v108
+// rescale-placement regressed, v109/v110 V-prefetch rings dipped, v102 all-8 rescale
+// starved the pipe) and pure softmax reorders (v112/v113/v114/v115) only tie. So v116
+// leaves the entire QK^T D-tile ring + PV WMMA schedule + softmax of v106 BYTE-FOR-BYTE
+// untouched, and attacks the ONE structural lever never applied to the v100+ family:
+// the EXPOSED COLD K LOAD AT EACH KV-TILE HEAD.
+//
+// THE BOTTLENECK. v106's intra-tile K ring hides the kt>=2 D-tile loads of QK^T under the
+// kt-1 WMMAs, but the FIRST D-tile pair (kt=0) of every KV tile is a cold global load
+// issued at the top of the QK^T loop, and the very first two QK WMMAs of the tile stall on
+// its full VMEM latency. Across N/BLOCK_N = 64 (N=2048) .. 128 (N=4096) KV tiles that cold
+// head-of-tile latency is paid once per tile, on the critical path, with no matrix work to
+// cover it (PV of the previous tile has already retired by then).
+//
+// THE CHANGE (the ONLY change vs v106). Software-pipeline the KV loop by ONE tile, but
+// carry ONLY the next tile's kt=0 K pair (two bf16x8 fragments = 8 VGPR). The next tile's
+// kt=0 loads are ISSUED right before this tile's PV WMMA block, so their VMEM latency hides
+// in the shadow of the PV matrix pipe (playbook lever 4 "n_pipe=2 at the KV-block level",
+// proven in v63; playbook lever 1 "separate memory-issuing from VALU/matrix work"). At the
+// next tile's QK^T head the kt=0 fragments are already resident -> the first two QK WMMAs
+// issue with NO exposed cold-load latency. kt=1 is still cold-loaded at the head as in v106
+// (it overlaps the kt=0 WMMA), and kt>=2 keep v106's two-ahead ring verbatim.
+//
+// Why only the kt=0 pair (not the whole tile): carrying all 8 D-tiles would add 64 VGPR and
+// collapse occupancy (the v104 cliff). Carrying 4 fragments (kt=0,1) adds 16 VGPR -> 213 ->
+// drops 7->6 waves. Carrying the kt=0 pair adds exactly 8 VGPR: 197 -> 205, still <=208, so
+// 7 waves/SIMD are preserved (the same footprint as v100/v101). This buys the head-of-tile
+// latency hide WITHOUT the occupancy regression that killed every "carry more state" attempt.
+//
+// BIT-EXACTNESS. The kt=0 K fragments loaded for tile n are read from the SAME global
+// addresses whether cold-loaded at the head (v106) or prefetched at the end of tile n-1
+// (v116) -> byte-identical K operands. Every other load, the QK^T D-tile ring, the WMMA
+// operand order, the entire softmax (row_max tree position, exp2 args, serial row_sum, RNE
+// pack) and the entire PV schedule + rescale are v106 verbatim -> byte-identical row_max /
+// new_m / rescale / probs / l_row / O. The boundary prefetch is guarded n_tile+1 <
+// num_kv_tiles (no OOB; the last tile leaves the carry stale and unread).
+//
+// RISK: low-med. If the compiler spills past 205 (e.g. fails to free a transient) occupancy
+// could drop to 6 waves and regress; mitigated by carrying the minimum 8 VGPR. If the HW
+// scoreboard already covered the head-of-tile load via the previous tile's tail, v116 ties
+// v106. No correctness risk (pure address-equivalent reorder of one load).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast116(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v116_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v116_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v116(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast116(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    // ---- Cross-tile K prefetch carry: the kt=0 K pair of the CURRENT tile. Primed here
+    // for tile 0 (cold, unavoidable on the first tile), then refilled at the end of every
+    // tile with the NEXT tile's kt=0 pair so its VMEM latency hides under PV WMMAs.
+    bf16x8_t nk0, nk1;
+    {
+        const bf16_t* kb0 = Kp + (0 * BLOCK_N + col16) * stride_n + row8;
+        const bf16_t* kb1 = Kp + (0 * BLOCK_N + 16 + col16) * stride_n + row8;
+        nk0 = *reinterpret_cast<const bf16x8_t*>(kb0);
+        nk1 = *reinterpret_cast<const bf16x8_t*>(kb1);
+    }
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103/v106). The kt=0 pair is supplied
+        // from the cross-tile carry (already resident -> first two QK WMMAs do not stall on
+        // a cold load); kt=1 is cold-loaded here (overlaps the kt=0 WMMA); kt>=2 use the
+        // v106 two-ahead ring verbatim.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = nk0;   // carried kt=0 pair (== *(kbase0), same address)
+        kr1[0] = nk1;   // carried kt=0 pair (== *(kbase1), same address)
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v116_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v116_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast116(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast116(v_s1[j]);
+
+        // ---- Cross-tile K prefetch: issue the NEXT tile's kt=0 K pair NOW, so its global
+        // VMEM latency hides under the PV WMMA block below. At the next iteration's QK^T head
+        // these fragments are already resident. Guarded against OOB on the last tile.
+        if (n_tile + 1 < num_kv_tiles) {
+            const int nn_base = n_base + BLOCK_N;
+            const bf16_t* nkb0 = Kp + (nn_base + col16) * stride_n + row8;
+            const bf16_t* nkb1 = Kp + (nn_base + 16 + col16) * stride_n + row8;
+            nk0 = *reinterpret_cast<const bf16x8_t*>(nkb0);
+            nk1 = *reinterpret_cast<const bf16x8_t*>(nkb1);
+        }
+
+        // ---- PV: v106's 2-D-tile grouped PV (4 live V fragments, two independent
+        // accumulator chains per pair) with the online rescale SOFTWARE-PIPELINED BY ONE
+        // PAIR. Byte-for-byte identical to v106. DK=8 even -> exact pairing, no remainder.
+        if (need_rescale) {
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        }
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale: prepare the NEXT pair's accumulators while the
+            // current pair's V loads are in flight. Independent of the WMMAs below.
+            if (dt + 2 < DK && need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast116(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v117.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v117.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v117_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v117<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v117_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v117_template.hpp
@@ -1,0 +1,243 @@
+// v117 -- v106 champion (90.20 TFLOPS) + UNCONDITIONAL (BRANCHLESS) PV RESCALE FORM.
+//
+// Base choice: v106 (the MEASURED running best, 90.20 TFLOPS primary @ b4h32n4096).
+// QK^T, softmax math, V layout, the 2-D-tile grouped PV (4 live V fragments, two
+// independent accumulator chains per pair) and the one-pair-ahead rescale SCHEDULE are
+// all kept structurally identical to v106. v107-v116 already proved that restructuring
+// PV (mid-load rescale v107=85.3, split rescale v108=88.7, V-prefetch rings
+// v109=85.1/v110) or reordering softmax (v112-v115, tied) does not beat v106: every
+// register-adding change hits the ~207-VGPR / 7-wave occupancy cliff, and every
+// reorder ties. The ONE sanctioned lever never implemented is the round-7 reviewer's
+// "Next Lever 3": A/B the CONDITIONAL `if (need_rescale)` rescale against an
+// UNCONDITIONAL multiply.
+//
+// What changed vs v106 (the ONLY change): the three `if (need_rescale)` guards around
+// the O-accumulator and l_row rescales are REMOVED. rescale = exp2f(m_row - new_m) is
+// computed unconditionally and l_row, v_o[0..1] (prologue), and v_o[dt+2..dt+3] (the
+// one-pair-ahead step) are multiplied unconditionally.
+//
+// WHY THIS SHOULD HELP (primary, n=4096): online-softmax record maxima grow ~ln(N), so
+// `need_rescale` is TRUE on only ~a handful of the 64 KV tiles -- the rescale FMAs are
+// already cheap. Their real cost in v106 is NOT the arithmetic but the data-dependent
+// `s_cbranch` that fences the compiler's instruction scheduler at three points inside
+// PV: the scheduler cannot freely hoist/interleave the rescale FMAs with the V loads
+// and PV WMMAs across a branch boundary, which is exactly why v106's placement was so
+// fragile (v107/v108 moved it a little and regressed). The rescale FMAs are pure VALU
+// that co-issue with the WMMAs on a SEPARATE pipe (RDNA4 dual-issue), so running them
+// unconditionally costs ~0 matrix-pipe cycles while removing the three scheduler fences
+// -- letting the compiler pack the FMAs into the WMMA issue shadow with no barrier.
+// Zero added VGPR (no new live state), so occupancy is unchanged at 7 waves/SIMD.
+//
+// BIT-EXACTNESS (vs v106, provable):
+//   * When new_m == m_row: rescale = exp2f(0) = EXACTLY 1.0 (hw v_exp2_f32(0)=1.0).
+//     v106 skipped the multiply; v117 does `x * 1.0f`, which is the IEEE-754 identity
+//     (exact for every finite/inf/zero x; no rounding). l_row *= 1.0f likewise exact.
+//   * When new_m != m_row: v117 takes the same arithmetic path v106's branch took --
+//     same rescale value, same multiplies, same order.
+//   * First tile (m_row = -3.4e38): new_m = row_max != m_row in BOTH versions ->
+//     rescale = exp2f(-huge) = 0.0; v_o (already 0) *= 0 and l_row (0) *= 0 -> identical.
+// Every v_o[dt] is still rescaled EXACTLY ONCE before its own PV WMMA, same WMMA
+// operand order -> byte-identical row_max / new_m / rescale / probs / l_row / O.
+//
+// RISK: low. Correctness is an IEEE identity (verified by the n_bad==0 gate). Perf:
+// neutral-to-positive; if the compiler had already if-converted v106's branch this
+// simply ties v106 (no regression -- same instruction count, same VGPR).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast117(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v117_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v117_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v117(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast117(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // TWO-AHEAD software-pipelined K loads (v101/v103, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        const bf16_t* kbase0 = Kp + (n_base + col16) * stride_n + row8;
+        const bf16_t* kbase1 = Kp + (n_base + 16 + col16) * stride_n + row8;
+        bf16x8_t kr0[2];
+        bf16x8_t kr1[2];
+        kr0[0] = *reinterpret_cast<const bf16x8_t*>(kbase0);
+        kr1[0] = *reinterpret_cast<const bf16x8_t*>(kbase1);
+        if (DK > 1) {
+            kr0[1] = *reinterpret_cast<const bf16x8_t*>(kbase0 + W_K);
+            kr1[1] = *reinterpret_cast<const bf16x8_t*>(kbase1 + W_K);
+        }
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            const int cur = kt & 1;
+            bf16x8_t v_k0 = kr0[cur];
+            bf16x8_t v_k1 = kr1[cur];
+            if (kt + 2 < DK) {
+                kr0[cur] = *reinterpret_cast<const bf16x8_t*>(kbase0 + (kt+2) * W_K);
+                kr1[cur] = *reinterpret_cast<const bf16x8_t*>(kbase1 + (kt+2) * W_K);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v117_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        // UNCONDITIONAL (branchless) rescale: exp2f(0)=1.0 and x*1.0f is exact, so the
+        // no-rescale case is bit-identical to v106's skipped branch -- but with no
+        // data-dependent s_cbranch fencing the PV instruction scheduler.
+        const fp32_t rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+        l_row *= rescale;
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v117_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast117(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast117(v_s1[j]);
+
+        // ---- PV: v106's 2-D-tile grouped PV (4 live V fragments, two independent
+        // accumulator chains per pair) with the one-pair-ahead rescale SCHEDULE kept
+        // byte-for-byte. The ONLY change: the rescale multiplies are now UNCONDITIONAL
+        // (no `if (need_rescale)` guard), removing the scheduler-fencing branches so the
+        // rescale FMAs pack freely into the V-load + WMMA issue shadow. Each v_o[dt] is
+        // still rescaled exactly once before its PV WMMA -> bit-exact. DK=8 is even.
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[0][j] *= rescale;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[1][j] *= rescale;
+        #pragma unroll
+        for (int dt = 0; dt < DK; dt += 2) {
+            const int dt1 = dt + 1;
+            const bf16_t* a0 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1 = VTp + (dt  * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* b0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* b1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t va0 = *reinterpret_cast<const bf16x8_t*>(a0);
+            bf16x8_t va1 = *reinterpret_cast<const bf16x8_t*>(a1);
+            bf16x8_t vb0 = *reinterpret_cast<const bf16x8_t*>(b0);
+            bf16x8_t vb1 = *reinterpret_cast<const bf16x8_t*>(b1);
+            // One-pair-ahead rescale (UNCONDITIONAL): prepare the NEXT pair's
+            // accumulators while the current pair's V loads are in flight. Independent
+            // of the WMMAs below. exp2f(0)=1.0 -> *=1.0 is the IEEE identity when no
+            // rescale is needed, matching v106 bit-for-bit.
+            if (dt + 2 < DK) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 2][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt + 3][j] *= rescale;
+            }
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va0, v_p0, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb0, v_p0, v_o[dt1]);
+            v_o[dt]  = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(va1, v_p1, v_o[dt]);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(vb1, v_p1, v_o[dt1]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast117(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v118.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v118.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v118_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v118<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v118_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v118_template.hpp
@@ -1,0 +1,228 @@
+// v118 -- v100 champion (90.45 TFLOPS) + TWO-SUBTILE-PASS PV to maximally defer the
+// subtile-1 softmax tail out of the exposed QK->PV wedge.
+//
+// Base choice: v100 is the MEASURED running best. Every v101..v117 follow-up (deeper
+// K prefetch, all PV grouping/prefetch/rescale-split variants, tree softmax, an
+// unconditional-rescale VGPR cut to 9 waves/SIMD) FAILED to beat v100 at the canonical
+// shape. That is strong evidence the kernel is (a) NOT occupancy-bound and (b) past the
+// point where local per-D-tile / per-pair PV micro-reorders pay off. v118 therefore
+// keeps v100's QK^T byte-for-byte and makes ONE structural change to the PV phase.
+//
+// The bottleneck v100..v117 all left standing: every one of them keeps p0 and p1
+// INTERLEAVED inside each D-tile (or each pair) of PV -- the very first PV WMMA group
+// consumes BOTH v_p0 AND v_p1. So the ENTIRE softmax wedge, including subtile-1's
+// exp2(s1)+pack(p1) AND the full row_sum reduction, must retire before ANY PV matrix
+// work can begin. That wedge runs with the WMMA (matrix) pipe fully idle -- it is the
+// last big exposed serial region in the inner loop.
+//
+// v118 splits PV into TWO sequential passes over all D-tiles:
+//   pass A:  for dt in 0..DK-1:  v_o[dt] = wmma(v_v0[dt], v_p0, v_o[dt] * rescale)
+//   pass B:  for dt in 0..DK-1:  v_o[dt] = wmma(v_v1[dt], v_p1, v_o[dt])
+// Each accumulator v_o[dt] still receives EXACTLY rescale, then the p0 contribution,
+// then the p1 contribution, in that order -> BIT-EXACT vs v100 (same operands, same
+// WMMA order per accumulator). This is NOT the v48 split-PV dead-end: v48 split into
+// two INDEPENDENT accumulator chains that serialised on the single matrix pipe; v118
+// has ONE accumulator chain traversed twice over the two N-subtiles -- no extra
+// accumulator VGPR, exactly 1 live V fragment per pass.
+//
+// Why it should win: because pass A never touches v_p1, the producer of v_p1
+// (exp2(s1) + pack) AND the off-critical-path row_sum reduction are free to schedule
+// into pass A's 8-WMMA matrix-pipe shadow instead of in front of it. The exposed wedge
+// before the first PV WMMA shrinks from {exp2 s0+s1, pack p0+p1, full sum} down to just
+// {exp2 s0, pack p0}. v114 attempted a similar exp2/pack hoist but, keeping v106's
+// grouped PV, could only hide it behind the FIRST 2 WMMAs (p1 needed at the 3rd WMMA of
+// pair 0); v118 gives the s1 tail the full 8-WMMA pass-A shadow.
+//
+// VGPR: same fp32x8 O accumulators, V loaded JIT one fragment at a time (as v100's PV
+// did, no prefetch ring) -> footprint == v100, occupancy unchanged (7 waves/SIMD). No
+// LDS, no barriers. RISK: low; worst case the compiler already hoisted the s1 tail and
+// v118 ties v100. The split doubles the dt-loop trip count but the WMMA count is
+// identical (2*DK) so no arithmetic-throughput cost.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast118(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v118_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v118_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v118(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast118(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads (v100, byte-for-byte identical).
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1). row_max must read BOTH subtiles
+        // (unavoidable), but everything downstream of subtile 1 is pushed past pass A.
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v118_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        // --- Subtile-0 tail ONLY: exp2(s0) + pack(p0). This is the entire critical
+        // path that must retire before PV pass A can start.
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        bf16x8_t v_p0;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast118(v_s0[j]);
+
+        // ---- PV pass A: accumulate the subtile-0 (v_p0) contribution into every
+        // D-tile, applying the online rescale at each accumulator's head (v100's exact
+        // rescale point and value). V loaded JIT, one fragment at a time (v100 PV
+        // footprint -> no extra VGPR). Pass A touches NEITHER v_p1 NOR row_sum.
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+        }
+
+        // --- Subtile-1 tail: exp2(s1) + pack(p1) + the FULL row_sum reduction. These
+        // are emitted AFTER pass A so the compiler can sink them into pass A's 8-WMMA
+        // matrix-pipe shadow (VALU + transcendental overlapping the matrix pipe). p1 is
+        // first needed in pass B; l_row is consumed only after the whole KV loop, so the
+        // sum is fully off the critical path.
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+        bf16x8_t v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast118(v_s1[j]);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v118_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        // ---- PV pass B: accumulate the subtile-1 (v_p1) contribution into every
+        // D-tile. Each v_o[dt] now has had rescale, then the p0 WMMA (pass A), then this
+        // p1 WMMA -> identical operand order to v100 -> bit-exact.
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast118(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v119.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v119.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v119_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v119<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v119_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v119_template.hpp
@@ -1,0 +1,218 @@
+// v119 -- v100 + TRUE KV-block software pipeline (n_pipe=2 at the matrix-pipe level).
+//
+// Base: v100 (measured champion, 90.45 TFLOPS) — the v39 fused-PV-rescale family with
+// K-load software pipelining inside QK^T. v101..v118 (18 versions) all stayed inside
+// v100's single-tile loop and only reshuffled PV / softmax / prefetched K, and NONE
+// beat v100. That local-reorder class is exhausted.
+//
+// The untouched bottleneck is structural: in v100 each KV tile runs strictly
+//     QK^T(t) -> softmax(t) -> PV(t)
+// so the softmax wedge (exp2 + max/sum cross-half reduce + bf16 pack) executes with the
+// WMMA *matrix* pipe completely IDLE. It is the last large exposed serial region.
+//
+// Lever (playbook #4, "n_pipe=2 at the KV-block granularity"): the QK^T of tile t+1 is
+// data-independent of the softmax of tile t (it reads only Q and K[t+1]). So we hoist
+// the next tile's QK^T WMMAs to run BEFORE PV(t):
+//     softmax(t)  [VALU]   --->  QK^T(t+1) [MATRIX, overlaps softmax drain]  --->  PV(t)
+// The independent matrix work of QK^T(t+1) now fills the softmax-VALU shadow that was
+// previously a matrix-pipe bubble, and its K-load latency is hidden behind softmax+PV.
+// This is distinct from v116 (which only PREFETCHED K across tiles but still issued the
+// QK^T WMMAs inside the next iteration, after the v_o dependency chain blocked hoisting).
+//
+// Bit-exactness: per-tile arithmetic order is byte-for-byte v100. We only changed *when*
+// the (independent) QK^T(t+1) WMMAs are emitted relative to softmax(t)/PV(t); the values
+// they produce, the m_row/l_row update sequence, the rescale, the pack, and the v_o
+// accumulation order are all unchanged. -> bit-exact in bf16.
+//
+// VGPR cost: one extra score pair (v_s0_next/v_s1_next = 16 fp32) live across PV, over
+// v100's ~205. Should stay under 256 (perhaps dropping 7->6 waves/SIMD); the kernel is
+// not occupancy-bound (v117 added 2 waves with no gain), so trading a wave for a busy
+// matrix pipe during softmax is the intended bet.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast119(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v119_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v119_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v119(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast119(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    // ---- QK^T for a KV tile (K-load software pipelined, identical to v100's QK^T) ----
+    // Emits 2*DK independent WMMAs accumulating into s0,s1. No dependence on softmax/PV
+    // state -> safe to hoist ahead of the current tile's PV.
+    auto qkt = [&](int n_base, fp32x8_t& s0, fp32x8_t& s1) {
+        s0 = (fp32x8_t){0,0,0,0,0,0,0,0};
+        s1 = (fp32x8_t){0,0,0,0,0,0,0,0};
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], s0);
+            s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], s1);
+        }
+    };
+
+    // Prologue: QK^T of tile 0.
+    fp32x8_t v_s0, v_s1;
+    qkt(0, v_s0, v_s1);
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- softmax over the 16 current scores (8 from s0, 8 from s1) [VALU only] ----
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v119_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v119_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast119(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast119(v_s1[j]);
+
+        // ---- KV pipeline: issue NEXT tile's QK^T (matrix) BEFORE PV(t). These WMMAs are
+        // independent of the softmax above and of v_o, so they fill the matrix-pipe shadow
+        // of the softmax VALU and prefetch+consume K[t+1] under PV(t). ----
+        fp32x8_t v_s0_next, v_s1_next;
+        const bool has_next = (n_tile + 1 < num_kv_tiles);
+        if (has_next) {
+            qkt((n_tile + 1) * BLOCK_N, v_s0_next, v_s1_next);
+        }
+
+        // ---- PV: two WMMAs per D-tile, rescale fused per D-tile (v100 structure) ----
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+
+        // Roll the pipeline: next tile's scores become current.
+        v_s0 = v_s0_next;
+        v_s1 = v_s1_next;
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast119(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v120.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v120.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v120_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v120<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v120_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v120_template.hpp
@@ -1,0 +1,205 @@
+// v120 -- v100 champion (90.45 TFLOPS) + MINIMAL intra-PV-body load/rescale reorder.
+//
+// Base choice: v100 is the MEASURED running best on this box (v39 QK^T + 2-ahead K
+// prefetch, v39 per-D-tile PV). Rounds 1-10 (v110..v119) all tried to extend the PV
+// phase with persistent V-prefetch RINGS, one-pair-ahead rescale pipelines, or
+// KV-block pipelines -- every one REGRESSED (88.4, 67.3, 73-85). The decisive lesson:
+// any added V-fragment liveness across the PV WMMA quartet pushes the kernel over an
+// occupancy/allocation cliff (v39/v100 already sit at ~205 VGPR / 7 waves). So we do
+// NOT add a ring and we do NOT add any extra live registers.
+//
+// What changed vs v100 (the ONLY change, and it is liveness-NEUTRAL): in the
+// per-D-tile PV loop the two V loads are ISSUED FIRST, then the online rescale FMAs of
+// THIS SAME D-tile's accumulator run, then the two WMMAs consume the loaded V. v100
+// emits rescale-FMAs BEFORE the V loads, so the loads issue late and the very next
+// WMMA can stall waiting on VMEM. By emitting the loads first, the ~8 rescale FMAs
+// (VALU pipe) execute in the shadow of the in-flight V-load latency (VMEM pipe), and
+// the WMMA's load-use distance grows by exactly the rescale block -- with no ring,
+// no next-buffer, the SAME two v_v0/v_v1 registers v100 already used. This is the
+// reviewer's lever 3 ("instruction-level scheduling inside v106's existing PV body,
+// no persistent ring") applied to the simpler v100 PV (per-D-tile, not paired).
+//
+// Arithmetic is byte-for-byte identical to v100: each v_o[dt] is rescaled exactly
+// once (same value, same order) before its two PV WMMAs; QK^T, softmax, exp2, pack,
+// and final normalize are untouched -> bit-exact in bf16.
+//
+// VGPR/occupancy: identical to v100 (no new live values) -> 7 waves/SIMD preserved.
+// RISK: low. If the compiler already hoisted v100's V loads above the rescale, v120
+// simply ties v100. Worst realistic case is a scheduling wash, not a regression.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast120(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v120_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v120_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v120(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast120(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v120_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v120_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast120(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast120(v_s1[j]);
+
+        // ---- PV: two WMMAs per D-tile, rescale fused per D-tile (v39/v100 structure).
+        // MINIMAL liveness-neutral reorder vs v100: ISSUE the two V loads FIRST so the
+        // VMEM fetch is in flight, THEN run this D-tile's rescale FMAs (VALU pipe) in
+        // the load shadow, THEN consume V in the WMMAs. Same two registers, no ring,
+        // no extra liveness -> identical VGPR/occupancy and bit-exact arithmetic.
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            // Rescale THIS accumulator while the V loads above are in flight (VALU in
+            // the VMEM-latency shadow). Independent of v_v0/v_v1; grows load-use
+            // distance to the WMMAs below without adding any live register.
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast120(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v121.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v121.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v121_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v121<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v121_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v121_template.hpp
@@ -1,0 +1,223 @@
+// v121 -- v100 champion (K-prefetch QK^T + direct-load v39 PV) + a WAVE-UNIFORM
+//          rescale split in the PV phase. Bit-exact, no added V-fragment liveness.
+//
+// Base: v100 (the measured champion, ~89.4-90.45 TFLOPS). v100's PV body carries a
+// per-D-tile, per-lane data-dependent branch:
+//     for (dt) { if (need_rescale) for(j) v_o[dt][j] *= rescale;  load V; 2x WMMA; }
+// `need_rescale = (new_m != m_row)` is computed per query-row (per lane). The director
+// note + last reviewer flagged that the V-prefetch family all REGRESSED by extending
+// V-fragment liveness across this rescale machinery at the ~205 VGPR / 7-wave cliff.
+// The reviewer's explicit NEXT lever: "reduce PV peak liveness instead of hiding V
+// latency: split or specialize the rescale path."
+//
+// THE CHANGE (PV only): hoist the rescale decision to a WAVE-UNIFORM predicate and
+// split PV into two specialized loop bodies:
+//   any_rescale = (__builtin_amdgcn_ballot_w32(need_rescale) != 0ull);  // wave-uniform
+//   if (any_rescale)  -> "slow" body: rescale all v_o[dt] then 2x WMMA (v100 math)
+//   else              -> "fast" body: NO rescale multiplies at all, just V load + WMMA
+// WMMAs are wave-cooperative, so the predicate MUST be wave-uniform (ballot), never the
+// per-lane branch around a WMMA. The fast body removes the rescale FMAs and the
+// `rescale` register's liveness from the common-case PV loop entirely -> less VALU and
+// less live state in the exact window where the fp32x8 O accumulator pressure peaks.
+//
+// WHY IT'S COMMON: after the first few KV tiles m_row converges to the row's global
+// max, so on the vast majority of KV tiles NO lane sees a new maximum -> ballot==0 ->
+// the fast body runs. v100 still pays the per-lane branch + the `*= 1.0f` identity-mult
+// liveness on those tiles; v121 skips it cleanly.
+//
+// BIT-EXACTNESS: in the slow body EVERY lane executes `v_o[dt][j] *= rescale`, but
+// lanes that did NOT need rescale have rescale == 1.0f, and `x * 1.0f == x` bit-exactly
+// for all finite x -> identical to v100 (which skipped the multiply for those lanes).
+// In the fast body NO lane needed rescale, so v100 also skipped every multiply ->
+// identical. The reduction order, exp2, l_row, bf16 pack, both WMMA phases and the
+// QK^T K-prefetch ring are byte-for-byte v100. n_bad(>0.05)=0, max_abs ~ 1e-4.
+//
+// VGPR: <= v100 (the fast body drops `rescale` liveness; ballot is a single s-reg op).
+// No LDS, no barriers, no V prefetch, no new buffers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast121(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v121_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v121_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v121(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast121(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v121_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v121_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast121(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast121(v_s1[j]);
+
+        // ---- PV: two WMMAs per D-tile, direct V loads (v39/v100 structure).
+        // WAVE-UNIFORM rescale split: only enter the rescale path if SOME lane in the
+        // wave actually saw a new row maximum this KV tile. After m_row converges this
+        // is false on most tiles -> the fast body runs with no rescale FMAs and no
+        // `rescale` liveness. The predicate is wave-uniform (ballot) so the WMMAs stay
+        // wave-cooperative. Bit-exact: in the slow body lanes that didn't need rescale
+        // carry rescale==1.0f and `x*1.0f==x`; in the fast body no lane needed it.
+        const bool any_rescale = (__builtin_amdgcn_ballot_w32(need_rescale) != 0u);
+        if (any_rescale) {
+            #pragma unroll
+            for (int dt = 0; dt < DK; ++dt) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        } else {
+            #pragma unroll
+            for (int dt = 0; dt < DK; ++dt) {
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast121(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v122.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v122.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v122_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v122<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v122_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v122_template.hpp
@@ -1,0 +1,224 @@
+// v122 -- v100 champion + CHUNKED (CHUNK=2) PV online-rescale schedule.
+//
+// PROVENANCE / why this round: the director's plateau note (round 13, mandate A)
+// asks to recover the speed of the "fast v111" (measured 91.6-92.3 TFLOPS in the
+// other ablation lane, the fastest kernel found) while keeping v100's EXACT fp32
+// accumulation order. Investigation of the ledgers shows the fast v111 is the
+// CHUNK=2 PV-rescale schedule, and that lane's reported max_abs=0.0360 is a
+// lane-LOCAL verify artifact: in that lane EVERY version from v103 onward reports
+// the identical 0.0360 regardless of the change (even an fp-contract(off) build),
+// while THIS lane reports 0.0001 for the byte-identical sources. So the 0.0360 is
+// not produced by the chunked schedule; the schedule itself is the real +1.5 TFLOPS
+// lever and it has NEVER been measured in this (clean-verify) lane.
+//
+// THE CHANGE (PV phase only; QK^T / softmax / exp2 / sum / pack / normalize are all
+// byte-for-byte v100): v100 applies the online rescale to all 8 O accumulators in
+// one monolithic VALU pass, THEN runs the 8-D-tile PV WMMA loop. v122 instead walks
+// the D-tiles in CHUNK=2 groups; for each group it (a) rescales just that group's 2
+// O fragments, then (b) issues that group's V loads + PV WMMAs. The next group's
+// rescale FMAs (VALU pipe) then overlap the current group's PV WMMAs (matrix pipe),
+// and no single VALU region keeps more than 2 fp32x8 O fragments hot -> shorter live
+// ranges and more scheduler freedom around the accumulator-pressure peak.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the arithmetic touching each
+// accumulator v_o[dt] is UNCHANGED from v100 -- for every dt it is still exactly
+// `v_o[dt] *= rescale` (only when need_rescale, same `rescale`), then the same two
+// WMMAs in the same order: wmma(v_v0,v_p0) then wmma(v_v1,v_p1). Chunking only
+// changes the INTERLEAVING of independent accumulators (v_o[0]'s ops vs v_o[2]'s
+// ops never share an fp32 reduction), which is associativity-neutral: the result
+// of each accumulator is rounding-identical to v100. row_max/row_sum/exp2/l_row are
+// untouched. -> n_bad=0, max_abs=0.0001 expected (same as v100 in this lane).
+//
+// WHY this differs from this lane's earlier v103 (89.68, no win): v103 *paired* the
+// V loads into two INDEPENDENT WMMA chains (v_o[dt] and v_o[dt+1] interleaved at the
+// WMMA level), which doubled live V fragments per group (4 V regs) and reordered the
+// WMMA issue. v122 keeps v100's single-chain per-dt WMMA order and only groups the
+// RESCALE -- minimal liveness delta, the lever the fast lane actually used.
+//
+// VGPR: ~v100 (~205, 7 waves/SIMD). No new V buffers, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast122(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v122_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v122_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v122(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast122(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v122_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v122_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast122(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast122(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast122(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v123.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v123.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v123_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v123<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v123_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v123_template.hpp
@@ -1,0 +1,236 @@
+// v123 -- v122 (CHUNK=2 PV rescale) + one-step-ahead VT prefetch in the PV loop.
+//
+// PROVENANCE / why this round: the director's plateau note (round 13, mandate A)
+// asks to recover the speed of the "fast v111" (measured 91.6-92.3 TFLOPS in the
+// other ablation lane, the fastest kernel found) while keeping v100's EXACT fp32
+// accumulation order. Investigation of the ledgers shows the fast v111 is the
+// CHUNK=2 PV-rescale schedule, and that lane's reported max_abs=0.0360 is a
+// lane-LOCAL verify artifact: in that lane EVERY version from v103 onward reports
+// the identical 0.0360 regardless of the change (even an fp-contract(off) build),
+// while THIS lane reports 0.0001 for the byte-identical sources. So the 0.0360 is
+// not produced by the chunked schedule; the schedule itself is the real +1.5 TFLOPS
+// lever and it has NEVER been measured in this (clean-verify) lane.
+//
+// THE CHANGE (PV phase only; QK^T / softmax / exp2 / sum / pack / normalize are all
+// byte-for-byte v100): v100 applies the online rescale to all 8 O accumulators in
+// one monolithic VALU pass, THEN runs the 8-D-tile PV WMMA loop. v123 instead walks
+// the D-tiles in CHUNK=2 groups; for each group it (a) rescales just that group's 2
+// O fragments, then (b) issues that group's V loads + PV WMMAs. The next group's
+// rescale FMAs (VALU pipe) then overlap the current group's PV WMMAs (matrix pipe),
+// and no single VALU region keeps more than 2 fp32x8 O fragments hot -> shorter live
+// ranges and more scheduler freedom around the accumulator-pressure peak.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the arithmetic touching each
+// accumulator v_o[dt] is UNCHANGED from v100 -- for every dt it is still exactly
+// `v_o[dt] *= rescale` (only when need_rescale, same `rescale`), then the same two
+// WMMAs in the same order: wmma(v_v0,v_p0) then wmma(v_v1,v_p1). Chunking only
+// changes the INTERLEAVING of independent accumulators (v_o[0]'s ops vs v_o[2]'s
+// ops never share an fp32 reduction), which is associativity-neutral: the result
+// of each accumulator is rounding-identical to v100. row_max/row_sum/exp2/l_row are
+// untouched. -> n_bad=0, max_abs=0.0001 expected (same as v100 in this lane).
+//
+// WHY this differs from this lane's earlier v103 (89.68, no win): v103 *paired* the
+// V loads into two INDEPENDENT WMMA chains (v_o[dt] and v_o[dt+1] interleaved at the
+// WMMA level), which doubled live V fragments per group (4 V regs) and reordered the
+// WMMA issue. v123 keeps v100's single-chain per-dt WMMA order and only groups the
+// RESCALE -- minimal liveness delta, the lever the fast lane actually used.
+//
+// VGPR: ~v100 (~205, 7 waves/SIMD). No new V buffers, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast122(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v123_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v123_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v123(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast122(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v123_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v123_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast122(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast122(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        // One-step-ahead VT software pipeline (mirrors the QK^T K-load pipeline /
+        // playbook lever #3, v78): preload D-tile 0's V fragments, then load dt+1's
+        // V before issuing dt's PV WMMAs so the next VMEM load overlaps the current
+        // WMMA issue window. This moves ONLY the *timing* of the V loads; the bytes
+        // loaded and every arithmetic op on v_o[dt] are byte-for-byte v122 -> bit-exact.
+        // CHUNK=2 rescale grouping is preserved exactly (the round-13 winner).
+        const int vt_base0 = col16 * vt_stride_d + n_base + row8;
+        const int vt_base1 = col16 * vt_stride_d + n_base + 16 + row8;
+        bf16x8_t v_v0_next = *reinterpret_cast<const bf16x8_t*>(VTp + vt_base0);
+        bf16x8_t v_v1_next = *reinterpret_cast<const bf16x8_t*>(VTp + vt_base1);
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                bf16x8_t v_v0 = v_v0_next;
+                bf16x8_t v_v1 = v_v1_next;
+                if (dt + 1 < DK) {
+                    v_v0_next = *reinterpret_cast<const bf16x8_t*>(VTp + (dt + 1) * W_K * vt_stride_d + vt_base0);
+                    v_v1_next = *reinterpret_cast<const bf16x8_t*>(VTp + (dt + 1) * W_K * vt_stride_d + vt_base1);
+                }
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast122(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v124.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v124.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v124_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v124<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v124_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v124_template.hpp
@@ -1,0 +1,224 @@
+// v124 -- v122 (CHUNK=2 PV online-rescale) reverted clean of v123's PV prefetch,
+//          re-run with CHUNK=1 (finest rescale/WMMA interleave).
+//
+// PROVENANCE / why this round (round 15): v123 added a one-step-ahead VT prefetch to
+// the v122 PV loop and REGRESSED hard (77.89 vs the 91.68 bar). Root cause per the
+// reviewer: carrying v_v0_next/v_v1_next across the CHUNK rescale region extends the
+// V-fragment live ranges through VALU work + WMMA issue, costing occupancy / forcing
+// worse waitcnt placement -- the "V software-pipelining in PV" lever is now falsified
+// in this lane. So v124 (a) DROPS the PV prefetch entirely, returning to the exact
+// clean v122 PV schedule (short-lived per-dt V loads), and (b) sweeps the one knob
+// that controls VALU-rescale/WMMA interleave WITHOUT adding any new V-buffer liveness:
+// the rescale CHUNK size.
+//
+// v100 rescaled all 8 O accumulators in one monolithic VALU pass (== CHUNK=8) then ran
+// the PV WMMA loop. v122 split that into CHUNK=2 groups and won (91.68). The gradient
+// 8 -> 2 improved, so this round pushes to the finest grain: CHUNK=1. Each D-tile now
+// rescales JUST its own O fragment immediately before issuing that tile's two PV WMMAs,
+// so (i) only ONE fp32x8 O accumulator is hot in any VALU-rescale region (the minimum
+// possible accumulator-pressure peak), and (ii) tile dt+1's rescale FMAs (VALU pipe)
+// overlap tile dt's PV WMMAs (matrix pipe) at the tightest possible granularity. No new
+// registers vs v122 -- the only delta is the loop step, so VGPR pressure is <= v122.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the arithmetic touching each
+// accumulator v_o[dt] is UNCHANGED from v100/v122 -- for every dt it is still exactly
+// `v_o[dt] *= rescale` (only when need_rescale, same `rescale`), then the same two
+// WMMAs in the same order: wmma(v_v0,v_p0) then wmma(v_v1,v_p1). CHUNK only changes the
+// INTERLEAVING of INDEPENDENT accumulators (v_o[dt]'s ops never share an fp32 reduction
+// with v_o[dt'] for dt!=dt'), which is associativity-neutral: every accumulator's result
+// is rounding-identical to v100. row_max/row_sum/exp2/l_row are untouched. CHUNK=1
+// divides DK=8 exactly, so all 8 tiles are covered. -> n_bad=0, max_abs=0.0001 expected.
+//
+// WHY this differs from this lane's earlier v103 (89.68, no win): v103 *paired* the
+// V loads into two INDEPENDENT WMMA chains (v_o[dt] and v_o[dt+1] interleaved at the
+// WMMA level), which doubled live V fragments per group (4 V regs) and reordered the
+// WMMA issue. v124 keeps v100's single-chain per-dt WMMA order and only changes the
+// rescale grain -- minimal liveness delta, no extra V buffers.
+//
+// VGPR: <= v122 (~205, 7 waves/SIMD). No new V buffers, no prefetch, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast122(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v124_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v124_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v124(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast122(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v124_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v124_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast122(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast122(v_s1[j]);
+
+        // ---- PV: CHUNK=1 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 1 fp32x8 accumulator hot at CHUNK=1), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 1;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast122(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v125.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v125.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v125_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v125<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v125_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v125_template.hpp
@@ -1,0 +1,288 @@
+// v125 -- v122 champion + 2-KV-TILE FUSION (structural lever, mandate B / reviewer #2).
+//
+// PROVENANCE / why this round: round 13-15 exhausted instruction-level reshuffling of
+// the single-tile inner loop (CHUNK sweeps, V prefetch, rescale splits all tied or
+// regressed; v124 CHUNK=1 lost 2.8%). The reviewer and the director's plateau note
+// both mandate the next STRUCTURAL move: process TWO KV tiles per WG iteration so the
+// loop/softmax/PV setup is amortized and -- the real lever -- the independent QK^T
+// WMMA window doubles (8 -> 16 WMMAs in flight across two tiles), letting the matrix
+// pipe stay fed while tile-(t+1)'s global K loads are still in flight. This is the
+// "enlarge the independent WMMA window without resurrecting V-fragment liveness"
+// path the round-15 reviewer asked for.
+//
+// THE CHANGE (loop structure only; per-tile arithmetic is byte-for-byte v122/v100):
+//   for n_tile in [0, num_kv_tiles) step 2:
+//     (1) QK^T for BOTH tiles a=n_tile and b=n_tile+1, with the two tiles' WMMAs
+//         INTERLEAVED per D-tile (k0a,k1a,k0b,k1b loaded, then 4 WMMAs issued). The
+//         4 independent score accumulators (s0a,s1a,s0b,s1b) give the matrix pipe a
+//         2x wider window and overlap b's K loads behind a's WMMAs.
+//     (2) tile a: full v122 online softmax (row_max, new_m, rescale_a, exp2, sum,
+//         l_row update, bf16 pack -> p0a,p1a). Frees s0a,s1a.
+//     (3) tile b: full v122 online softmax using m_row AFTER tile a (sequential
+//         online-softmax dependency preserved) -> rescale_b, p0b,p1b. Frees s0b,s1b.
+//     (4) PV a: v_o *= rescale_a (CHUNK=2), then V_a@P_a accumulate (CHUNK=2).
+//     (5) PV b: v_o *= rescale_b (CHUNK=2), then V_b@P_b accumulate (CHUNK=2).
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): every value is produced in the
+// SAME order as v122 running n_tile=a then n_tile=b:
+//   * m_row/l_row updates are sequential a-then-b exactly as before (b reads m_row
+//     and l_row produced by a). No reassociation of the row-sum or the cross-tile
+//     online reduction.
+//   * Each O accumulator evolves as ((v_o * rescale_a) + V_a@P_a) * rescale_b +
+//     V_b@P_b -- identical operation order to two v122 iterations.
+//   * Computing tile b's exp2/sum/pack BEFORE PV_a is reorder-safe: those touch only
+//     tile-b values + l_row, and PV_a never reads/writes l_row, so l_row's a-then-b
+//     update order is unchanged. QK WMMA interleaving only reorders INDEPENDENT
+//     accumulators (s*a vs s*b never share a reduction). -> n_bad=0, max_abs=0.0001.
+//
+// LIVENESS / risk: peak score liveness moves to the QK phase (4 fp32x8 score frags +
+// up to 8 K bf16x8 buffers) which is transient and does NOT overlap the V loads. The
+// PV phase keeps v122's short-lived per-dt V loads (only p0a/p1a/p0b/p1b bf16 carried
+// in, 2 VGPR each) -- explicitly NOT the long-lived V prefetch that sank v123. Extra
+// pressure vs v122 is the second score-frag pair + second K double-buffer; if this
+// drops 7->6 waves the QK window widening must outweigh it (the bet).
+//
+// Requires num_kv_tiles even: num_kv_tiles = N/BLOCK_N = N/32, and N%64==0 (harness),
+// so N/32 is always even. Safe for all gated shapes (N=2048/4096/1536).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast125(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v125_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v125_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v125(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast125(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; n_tile += 2) {
+        const int n_base_a = n_tile * BLOCK_N;
+        const int n_base_b = n_base_a + BLOCK_N;
+
+        // ---- (1) QK^T for BOTH tiles, WMMAs interleaved per D-tile.
+        fp32x8_t v_s0a = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1a = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s0b = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1b = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0a_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_a + col16) * stride_n + row8);
+        bf16x8_t v_k1a_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_a + 16 + col16) * stride_n + row8);
+        bf16x8_t v_k0b_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_b + col16) * stride_n + row8);
+        bf16x8_t v_k1b_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_b + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0a = v_k0a_n;
+            bf16x8_t v_k1a = v_k1a_n;
+            bf16x8_t v_k0b = v_k0b_n;
+            bf16x8_t v_k1b = v_k1b_n;
+            if (kt + 1 < DK) {
+                const int o = (kt + 1) * W_K + row8;
+                v_k0a_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_a + col16) * stride_n + o);
+                v_k1a_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_a + 16 + col16) * stride_n + o);
+                v_k0b_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_b + col16) * stride_n + o);
+                v_k1b_n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_b + 16 + col16) * stride_n + o);
+            }
+            v_s0a = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0a, v_q[kt], v_s0a);
+            v_s1a = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1a, v_q[kt], v_s1a);
+            v_s0b = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0b, v_q[kt], v_s0b);
+            v_s1b = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1b, v_q[kt], v_s1b);
+        }
+
+        // ---- (2) tile a softmax (byte-for-byte v122 body on s0a/s1a).
+        fp32_t row_max_a = v_s0a[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max_a = __builtin_fmaxf(row_max_a, v_s0a[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max_a = __builtin_fmaxf(row_max_a, v_s1a[j]);
+        row_max_a = v125_cross_half_max(row_max_a);
+
+        const fp32_t new_m_a = __builtin_fmaxf(m_row, row_max_a);
+        fp32_t rescale_a = 1.0f;
+        const bool need_rescale_a = (new_m_a != m_row);
+        if (need_rescale_a) {
+            rescale_a = __builtin_amdgcn_exp2f(m_row - new_m_a);
+            l_row *= rescale_a;
+        }
+        m_row = new_m_a;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0a[j] = __builtin_amdgcn_exp2f(v_s0a[j] - new_m_a);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1a[j] = __builtin_amdgcn_exp2f(v_s1a[j] - new_m_a);
+        fp32_t row_sum_a = v_s0a[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum_a += v_s0a[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum_a += v_s1a[j];
+        row_sum_a = v125_cross_half_sum(row_sum_a);
+        l_row += row_sum_a;
+        bf16x8_t v_p0a, v_p1a;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0a[j] = bf16_fast125(v_s0a[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1a[j] = bf16_fast125(v_s1a[j]);
+
+        // ---- (3) tile b softmax (uses m_row/l_row AFTER tile a -> sequential online).
+        fp32_t row_max_b = v_s0b[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max_b = __builtin_fmaxf(row_max_b, v_s0b[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max_b = __builtin_fmaxf(row_max_b, v_s1b[j]);
+        row_max_b = v125_cross_half_max(row_max_b);
+
+        const fp32_t new_m_b = __builtin_fmaxf(m_row, row_max_b);
+        fp32_t rescale_b = 1.0f;
+        const bool need_rescale_b = (new_m_b != m_row);
+        if (need_rescale_b) {
+            rescale_b = __builtin_amdgcn_exp2f(m_row - new_m_b);
+            l_row *= rescale_b;
+        }
+        m_row = new_m_b;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0b[j] = __builtin_amdgcn_exp2f(v_s0b[j] - new_m_b);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1b[j] = __builtin_amdgcn_exp2f(v_s1b[j] - new_m_b);
+        fp32_t row_sum_b = v_s0b[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum_b += v_s0b[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum_b += v_s1b[j];
+        row_sum_b = v125_cross_half_sum(row_sum_b);
+        l_row += row_sum_b;
+        bf16x8_t v_p0b, v_p1b;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0b[j] = bf16_fast125(v_s0b[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1b[j] = bf16_fast125(v_s1b[j]);
+
+        // ---- (4) PV tile a (CHUNK=2, short-lived per-dt V loads -- v122 schedule).
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale_a) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale_a;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_a + row8;
+                const bf16_t* vt1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_a + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0a, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1a, v_o[dt]);
+            }
+        }
+
+        // ---- (5) PV tile b (CHUNK=2).
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale_b) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale_b;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_b + row8;
+                const bf16_t* vt1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_b + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0b, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1b, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast125(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v126.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v126.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v126_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v126<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v126_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v126_template.hpp
@@ -1,0 +1,237 @@
+// v126 -- v122 champion (CHUNK=2 PV rescale) + CROSS-TILE next-K prefetch.
+//
+// PROVENANCE / why this round (round 17): v122 = 91.68 TFLOPS is the champion. The
+// round-16 reviewer's explicit NEXT FOCUS after v125's 2-KV-fusion failed on the VGPR
+// /occupancy cliff (67 TFLOPS): "Revert to v122 and test a 'next-K prefetch only'
+// variant that overlaps tile-(t+1)'s K loads without keeping tile-b score
+// accumulators live." v125 died because it kept FOUR fp32x8 score fragments
+// (s0a,s1a,s0b,s1b = 32 VGPR) live across both tiles' softmax -- doubling the
+// accumulator-pressure peak that already sits at the 205->256 ceiling. The fix is to
+// overlap ONLY the next tile's K *loads* (2 bf16x8 = 8 VGPR), never its scores.
+//
+// THE CHANGE (K-load TIMING only; all arithmetic is byte-for-byte v122/v100):
+// v122's QK^T D-tile loop already runs a 2-deep K double-buffer (v_k0_next/v_k1_next),
+// but it PRIMES that buffer fresh at the TOP of every KV iteration -- so the first
+// WMMA of each tile waits on a COLD global K load (a guaranteed VMEM stall at the
+// start of every QK phase, num_kv_tiles times). v126 makes the prefetch ring wrap
+// ACROSS the KV-tile boundary: the K buffers are hoisted above the KV loop and primed
+// ONCE before it; inside each iteration the last D-tile (kt == DK-1) prefetches the
+// NEXT KV tile's dt=0 K columns (n_base + BLOCK_N) instead of going idle. Those loads
+// are then in flight through the entire softmax + CHUNK=2 PV phase (a long VALU/WMMA
+// region with no K dependency), so when the next iteration's first QK WMMA fires its
+// K operand is already resident -> the per-tile cold-load stall is eliminated.
+//
+// LIVENESS / VGPR (the lesson from v125 and v123/v124): the only state carried across
+// the iteration boundary is the SAME two K buffers v122 already allocates -- their
+// live range is extended from "within the QK loop" to "across softmax+PV", costing at
+// most one occupancy tier of headroom (8 VGPR), NOT the 32 VGPR of score fragments
+// that broke v125. No new V buffers (v123/v124 falsified PV-side prefetch), no LDS, no
+// score-fragment doubling. Expected VGPR ~205-213, still 7 waves/SIMD.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): NOTHING in the arithmetic changes.
+// The QK WMMAs consume identical K/Q operands in identical order (kt=0..DK-1, s0 then
+// s1); only WHEN the K bytes are fetched from DRAM moves earlier. Softmax, exp2,
+// row_max/row_sum reductions, the CHUNK=2 PV rescale+WMMA order, and normalize are all
+// byte-for-byte v122. Prefetching K for a tile that exists (guarded by n_tile+1 <
+// num_kv_tiles) reads only valid memory; the final tile does not prefetch. Each v_o[dt]
+// result is rounding-identical to v122 -> n_bad=0, max_abs=0.0001 expected.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast126(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v126_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v126_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v126(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast126(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    // ---- Cross-tile K prefetch ring (v126): the 2-deep K double-buffer is hoisted
+    // ABOVE the KV loop and primed ONCE with tile 0's dt=0 K. Inside each iteration the
+    // last D-tile prefetches the NEXT KV tile's dt=0 K, so the buffer is never re-primed
+    // from a cold load at the top of a QK phase -- the next tile's K is fetched during
+    // this tile's softmax+PV (a long region with no K dependency).
+    bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (0 + col16) * stride_n + row8);
+    bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (0 + 16 + col16) * stride_n + row8);
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+        const int n_base_next = n_base + BLOCK_N;  // next KV tile's column base
+        const bool have_next_tile = (n_tile + 1 < num_kv_tiles);
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // K loads are pipelined 2-deep AND wrap across the KV-tile boundary: for the
+        // last D-tile (kt==DK-1) we prefetch the NEXT tile's dt=0 K (guarded), so its
+        // VMEM latency hides behind this tile's softmax + PV WMMAs.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                // prefetch next D-tile of the CURRENT KV tile
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            } else if (have_next_tile) {
+                // last D-tile: prefetch dt=0 of the NEXT KV tile (cross-tile wrap)
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_next + col16) * stride_n + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_next + 16 + col16) * stride_n + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v126_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v126_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast126(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast126(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast126(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v127.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v127.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v127_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v127<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v127_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v127_template.hpp
@@ -1,0 +1,234 @@
+// v127 -- v100 champion + CHUNKED (CHUNK=2) PV online-rescale schedule.
+//
+// PROVENANCE / why this round: the director's plateau note (round 13, mandate A)
+// asks to recover the speed of the "fast v111" (measured 91.6-92.3 TFLOPS in the
+// other ablation lane, the fastest kernel found) while keeping v100's EXACT fp32
+// accumulation order. Investigation of the ledgers shows the fast v111 is the
+// CHUNK=2 PV-rescale schedule, and that lane's reported max_abs=0.0360 is a
+// lane-LOCAL verify artifact: in that lane EVERY version from v103 onward reports
+// the identical 0.0360 regardless of the change (even an fp-contract(off) build),
+// while THIS lane reports 0.0001 for the byte-identical sources. So the 0.0360 is
+// not produced by the chunked schedule; the schedule itself is the real +1.5 TFLOPS
+// lever and it has NEVER been measured in this (clean-verify) lane.
+//
+// THE CHANGE (PV phase only; QK^T / softmax / exp2 / sum / pack / normalize are all
+// byte-for-byte v100): v100 applies the online rescale to all 8 O accumulators in
+// one monolithic VALU pass, THEN runs the 8-D-tile PV WMMA loop. v127 instead walks
+// the D-tiles in CHUNK=2 groups; for each group it (a) rescales just that group's 2
+// O fragments, then (b) issues that group's V loads + PV WMMAs. The next group's
+// rescale FMAs (VALU pipe) then overlap the current group's PV WMMAs (matrix pipe),
+// and no single VALU region keeps more than 2 fp32x8 O fragments hot -> shorter live
+// ranges and more scheduler freedom around the accumulator-pressure peak.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the arithmetic touching each
+// accumulator v_o[dt] is UNCHANGED from v100 -- for every dt it is still exactly
+// `v_o[dt] *= rescale` (only when need_rescale, same `rescale`), then the same two
+// WMMAs in the same order: wmma(v_v0,v_p0) then wmma(v_v1,v_p1). Chunking only
+// changes the INTERLEAVING of independent accumulators (v_o[0]'s ops vs v_o[2]'s
+// ops never share an fp32 reduction), which is associativity-neutral: the result
+// of each accumulator is rounding-identical to v100. row_max/row_sum/exp2/l_row are
+// untouched. -> n_bad=0, max_abs=0.0001 expected (same as v100 in this lane).
+//
+// WHY this differs from this lane's earlier v103 (89.68, no win): v103 *paired* the
+// V loads into two INDEPENDENT WMMA chains (v_o[dt] and v_o[dt+1] interleaved at the
+// WMMA level), which doubled live V fragments per group (4 V regs) and reordered the
+// WMMA issue. v127 keeps v100's single-chain per-dt WMMA order and only groups the
+// RESCALE -- minimal liveness delta, the lever the fast lane actually used.
+//
+// VGPR: ~v100 (~205, 7 waves/SIMD). No new V buffers, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast127(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v127_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v127_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v127(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast127(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // v127 narrow intra-tile QK scheduling change (vs v122): the two next-D-tile
+        // K refills are SPLIT so each is issued immediately before the WMMA that does
+        // NOT consume it. v122 issued BOTH next-K loads back-to-back before BOTH
+        // WMMAs, so at the WMMA-issue point all 4 K fragments (v_k0,v_k1,v_k0_next,
+        // v_k1_next = 16 VGPR) were simultaneously live. v127 issues v_k0_next, then
+        // s0's WMMA (which overlaps that load; only v_k0/v_k1/v_k0_next live = 3
+        // frags), then v_k1_next, then s1's WMMA. Peak K-fragment liveness drops 4->3
+        // inside the QK loop and each VMEM load overlaps an independent WMMA's issue
+        // shadow. WMMA order (s0 then s1) and ALL arithmetic are byte-for-byte
+        // v122/v100 -> bit-exact (max_abs<=0.0001). Nothing kept live across softmax/PV.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            if (kt + 1 < DK) {
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v127_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v127_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast127(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast127(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast127(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v128.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v128.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v128_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v128<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v128_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v128_template.hpp
@@ -1,0 +1,251 @@
+// v128 -- v122 champion + V-HALF-SPLIT PV (widen the independent-WMMA window with
+//          ZERO added fragment liveness). Bit-exact vs v122/v100.
+//
+// PROVENANCE / why this round (round 19): v122 = 91.68 TFLOPS is the champion. The
+// director's plateau note says the single-tile K-prefetch lever is EXHAUSTED and
+// ~20 rounds of intra-loop reshuffling have tied or regressed. The ledger is blunt:
+//   * EVERY cross-boundary structural scheme fell off the ~205->256 VGPR / 7-wave
+//     occupancy cliff -- v116=83.8, v117=67.3, v118=73.1, v119=75.0 (hoist QK(t+1),
+//     carries score frags), v125=67.0 (2-KV fusion, 4 score frags), v126=82.0
+//     (cross-tile K carry). Adding ANY fragment across the KV-tile boundary loses.
+//   * EVERY pure permutation of v122's inner loop tied/regressed -- v123=77.9 (V
+//     prefetch), v124=89.1, v127=90.2 (QK reorder). Instruction shuffling is spent.
+// The round-18 reviewer's NEXT FOCUS: keep v122's QK^T verbatim (both next-K loads
+// issued early) and test a NO-NEW-FRAGMENT placement change in PV.
+//
+// THE INSIGHT (a real scheduling lever, not a permutation). v122's PV walks D-tiles
+// and per tile issues a 2-DEEP DEPENDENT WMMA CHAIN on the SAME accumulator:
+//     v_o[dt] = wmma(v_v0, v_p0, v_o[dt]);   // writes v_o[dt]
+//     v_o[dt] = wmma(v_v1, v_p1, v_o[dt]);   // STALLS on the previous write of v_o[dt]
+// The second WMMA of each tile cannot issue until the first has retired (RAW on
+// v_o[dt]). With CHUNK=2 the compiler interleaves two such chains, but the structure
+// still pairs each accumulator's two WMMAs back-to-back -> the matrix pipe repeatedly
+// eats the WMMA->WMMA accumulate latency.
+//
+// THE CHANGE (PV phase only; QK^T / softmax / exp2 / sum / pack / normalize are all
+// byte-for-byte v122): split PV into two passes BY V-HALF across ALL 8 accumulators.
+//   Pass A: for every dt -- rescale (CHUNK=2, exactly v122) then wmma(v_v0,v_p0,v_o[dt]).
+//           The 8 v0 WMMAs write 8 DISTINCT accumulators -> fully independent, an
+//           8-wide WMMA window with no intra-accumulator RAW stall.
+//   Pass B: for every dt -- wmma(v_v1,v_p1,v_o[dt]). Each depends on Pass A's same-dt
+//           result, but that WMMA retired ~7 issues earlier, so the accumulate latency
+//           is fully hidden behind the other tiles' Pass-B WMMAs.
+// Net: the same 16 WMMAs, but reordered so dependent pairs are maximally separated ->
+// the matrix pipe stops paying the per-tile WMMA->WMMA accumulate stall.
+//
+// LIVENESS / VGPR (why this is NOT v103/v104/v105 and NOT v125). The failed pairing
+// schemes (v103 "two independent chains per pair", v104/v105 "4-chain") kept FOUR V
+// fragments (v0a,v1a,v0b,v1b) live at once, and v125 kept four SCORE fragments live --
+// both blew past the occupancy cliff. v128 keeps EXACTLY ONE V fragment live at a time
+// (v_v0 in Pass A is dead after its WMMA; v_v1 loaded fresh in Pass B). That is FEWER
+// live V regs than v122's CHUNK=2 group (which holds v_v0 AND v_v1). So VGPR <= v122
+// (~205, 7 waves/SIMD) -- no new buffers, no LDS, no barriers, no score doubling.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005). For each accumulator v_o[dt] the
+// arithmetic is the IDENTICAL ordered sequence as v122/v100:
+//     v_o[dt] *= rescale   (only when need_rescale, same rescale)
+//     v_o[dt]  = wmma(v_v0, v_p0, v_o[dt])
+//     v_o[dt]  = wmma(v_v1, v_p1, v_o[dt])
+// Splitting the loop changes only the INTERLEAVING of operations belonging to
+// DIFFERENT (independent) accumulators -- v_o[0] and v_o[3] never share an fp32
+// reduction, so reordering their WMMAs is associativity-neutral. The intermediate
+// value of v_o[dt] handed from Pass A to Pass B is byte-identical to v122's value
+// between its two WMMAs. row_max (serial fmax), new_m, rescale, exp2(s0)/exp2(s1),
+// row_sum (serial add s0 then s1, then cross-half fold), l_row, the bf16 packs, and
+// the final normalize are ALL byte-for-byte v122. -> n_bad=0, max_abs=0.0001 expected.
+//
+// WHY this is distinct from v127 (90.24, QK reorder): v127 touched the QK^T half-tile
+// load schedule and shortened K lead time. v128 leaves QK^T verbatim (both next-K
+// loads early, as the reviewer mandated) and attacks the DIFFERENT bottleneck of the
+// PV dependent-WMMA-chain latency. The two are orthogonal.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast128(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v128_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v128_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v128(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast128(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile. BYTE-FOR-BYTE v122:
+        // both next-D-tile K loads (v_k0_next, v_k1_next) issued early so global VMEM
+        // overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // ---- Softmax over 16 values (8 from s0, 8 from s1). BYTE-FOR-BYTE v122.
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v128_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v128_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast128(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast128(v_s1[j]);
+
+        // ---- PV: V-HALF SPLIT. Pass A issues all 8 v0-half WMMAs (independent across
+        // accumulators -> 8-wide window), Pass B issues all 8 v1-half WMMAs (the same-dt
+        // dependency is hidden behind the other tiles' WMMAs). Per accumulator the order
+        // is exactly v122: `*= rescale` (if need_rescale), wmma(v_v0,v_p0), wmma(v_v1,v_p1).
+        // At most ONE V fragment is live at a time -> liveness <= v122's CHUNK=2 group.
+
+        // Pass A: rescale (CHUNK=2, exactly v122) + the v0-half WMMA for every D-tile.
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            }
+        }
+
+        // Pass B: the v1-half WMMA for every D-tile. Each depends on Pass A's same-dt
+        // accumulator write, but that retired ~7 WMMAs earlier -> latency fully hidden.
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast128(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v129.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v129.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v129_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v129<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v129_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v129_template.hpp
@@ -1,0 +1,239 @@
+// v129 -- v122 champion (CHUNK=2 PV rescale) + 1-deep DEFERRED-B PV software pipeline.
+//
+// PROVENANCE: v122 (91.68 TFLOPS, this lane's champion) issues PV as, per D-tile dt:
+//   rescale(o[dt]); A_dt = wmma(v0,p0,o[dt]); B_dt = wmma(v1,p1,o[dt]);
+// The two WMMAs for the SAME accumulator are back-to-back, so B_dt has a RAW
+// dependency on A_dt's matrix-pipe result with NO independent WMMA between them ->
+// the WMMA accumulate latency is exposed once per D-tile.
+//
+// Round 19's v128 tried to fix this by full V-half splitting (Pass A = all 8 A_dt,
+// Pass B = all 8 B_dt). That maximised WMMA separation but DESTROYED V-load lead
+// time: Pass B re-issued 8 fresh v1 loads with immediate load->WMMA use, exposing
+// global VMEM latency -> regressed to 73.5 TFLOPS. The reviewer's diagnosis: keep
+// V-load lead time, but separate each accumulator's two WMMAs by only 1-2 other
+// (independent) WMMAs -- a small rotating schedule, not a full pass split.
+//
+// THE CHANGE (PV phase only; QK^T/softmax/exp2/sum/pack/normalize byte-for-byte
+// v122): a 1-deep software pipeline that DEFERS the v1-half WMMA (B) by one D-tile.
+// Per dt we still load BOTH v0 and v1 together (lead time preserved, exactly as
+// v122), issue A_dt immediately, but issue the PREVIOUS tile's B_{dt-1} instead of
+// B_dt. So the instruction stream becomes:
+//   ... A_{dt-1}; B_{dt-2}; A_dt; B_{dt-1}; A_{dt+1}; B_dt; ...
+// Now between A_{dt} (write to o[dt]) and B_{dt} (read o[dt]) sits A_{dt+1} -- one
+// independent WMMA on a different accumulator -- so the accumulate latency of A_dt
+// is hidden behind A_{dt+1} instead of stalling B_dt. V loads still lead their use
+// by a full tile (both halves prefetched at the top of each dt step), so no VMEM
+// bubble is introduced. Liveness adds exactly ONE bf16x8 carry (v1 + its index)
+// across one loop step -> ~+1 VGPR, well below the occupancy cliff.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): every accumulator v_o[dt] sees the
+// IDENTICAL ops in the IDENTICAL order as v122: `*= rescale` (only if need_rescale,
+// same rescale), then wmma(v_v0,v_p0,o[dt]), then wmma(v_v1,v_p1,o[dt]). The pipeline
+// only changes WHEN B_dt is issued relative to OTHER accumulators' WMMAs -- never the
+// order of the two WMMAs touching the same o[dt], and independent accumulators never
+// share an fp32 reduction. Associativity-neutral -> rounding-identical to v122/v100.
+// The rescale of o[dt] still happens (CHUNK=2 group) strictly before A_dt, and B_dt
+// is the last write to o[dt] before normalize, so the deferral cannot race rescale of
+// a later tile (rescale of o[dt] for the NEXT n_tile only runs after this tile's B_dt
+// has retired the accumulator). -> n_bad=0, max_abs=0.0001 expected.
+//
+// VGPR: ~v122 (+1 carry reg, ~205, 7 waves/SIMD). No LDS, no barriers, no extra loads.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast129(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v129_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v129_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v129(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast129(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v129_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v129_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast129(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast129(v_s1[j]);
+
+        // ---- PV: online rescale (CHUNK=2 liveness) then a 1-deep DEFERRED-B pipeline.
+        //
+        // Step 1: rescale all O accumulators. Walked in CHUNK=2 groups so no VALU
+        // region keeps more than 2 fp32x8 accumulators hot (identical to v122's
+        // rescale-group liveness). For each o[dt] this is exactly `*= rescale` (only
+        // if need_rescale) and runs strictly before any WMMA touching o[dt] -> the
+        // per-accumulator op order is byte-for-byte v100/v122.
+        constexpr int CHUNK = 2;
+        if (need_rescale) {
+            #pragma unroll
+            for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+        }
+
+        // Step 2: deferred-B PV. Per D-tile we load BOTH V halves together (full
+        // tile of V-load lead time, exactly as v122 -- no Pass-B load-use bubble),
+        // issue A_dt = wmma(v0,p0,o[dt]) immediately, but DEFER the v1-half WMMA to
+        // the NEXT iteration: we issue the PREVIOUS tile's B_{dt-1} after A_dt. The
+        // emitted WMMA stream is  A0 | A1 B0 | A2 B1 | ... | A7 B6 | B7, so between
+        // A_dt (writes o[dt]) and B_dt (reads o[dt]) sits A_{dt+1} -- one independent
+        // WMMA on a different accumulator -- hiding A_dt's accumulate latency instead
+        // of stalling B_dt back-to-back as v122 did. Per accumulator the two WMMAs
+        // are still in order A_dt then B_dt, and independent accumulators never share
+        // an fp32 reduction -> bit-exact vs v122. Carries one bf16x8 (v_v1_prev).
+        bf16x8_t v_v1_prev;
+        #pragma unroll
+        for (int dt = 0; dt < DK; ++dt) {
+            const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+            bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+            v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+            if (dt > 0)
+                v_o[dt-1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_prev, v_p1, v_o[dt-1]);
+            v_v1_prev = v_v1;
+        }
+        v_o[DK-1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_prev, v_p1, v_o[DK-1]);
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast129(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v130.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v130.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v130_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v130<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v130_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v130_template.hpp
@@ -1,0 +1,240 @@
+// v130 -- v122 champion (CHUNK=2 PV rescale) + PAIRWISE "A0 A1 B0 B1" PV schedule.
+//
+// PROVENANCE: v122 (91.68 TFLOPS, the running best) issues PV per D-tile as
+//   rescale(o[dt]); A_dt = wmma(v0,p0,o[dt]); B_dt = wmma(v1,p1,o[dt]);
+// with A_dt and B_dt back-to-back. B_dt has a RAW dependency on A_dt's matrix-pipe
+// result with NO independent WMMA between them, so the WMMA accumulate latency is
+// exposed once per D-tile. Round 19's v128 fixed this with a FULL V-half pass split
+// (all 8 A, then all 8 B) but lost V-load lead time on Pass B -> 73.5 (VMEM bubble).
+// Round 20's v129 tried a 1-deep deferred-B pipeline with a loop-carried v_v1_prev
+// carry -> 87.69, slower than v122: the loop-carried live range + prologue/drain cost
+// more than the RAW it hid. The reviewer's mandated next lever: a PAIRWISE schedule
+// with both V halves loaded up front for the pair and NO loop-carried state.
+//
+// THE CHANGE (PV phase only; QK^T / softmax / exp2 / sum / pack / normalize are all
+// byte-for-byte v122/v100): v122 already walks the D-tiles in CHUNK=2 groups for the
+// rescale. v130 reuses that grouping for the WMMAs too: per group it loads BOTH V
+// halves for BOTH tiles up front (full load->use lead time, no Pass-B bubble), then
+// issues the WMMA stream  A0 A1 B0 B1  instead of v122's  A0 B0 A1 B1. Now between
+// A0 (write o[dt0]) and B0 (read o[dt0]) sits A1 -- one independent WMMA on a
+// different accumulator -- so A0's accumulate latency hides behind A1 rather than
+// stalling B0. Same for the second pair across the group boundary's interleave. This
+// is the per-pair version of v129's idea WITHOUT any loop-carried carry: all 4 V
+// fragments are local to the group iteration, so no extra live range survives the
+// loop step -> register-neutral vs v122 (unlike v129's +1 carry).
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the arithmetic touching each
+// accumulator v_o[dt] is UNCHANGED from v122/v100 -- for every dt it is still exactly
+// `v_o[dt] *= rescale` (only when need_rescale, same `rescale`), then the same two
+// WMMAs in the same order: wmma(v_v0,v_p0) then wmma(v_v1,v_p1). Reordering only
+// changes the INTERLEAVING of independent accumulators (o[dt0]'s ops vs o[dt1]'s ops
+// never share an fp32 reduction), which is associativity-neutral: each accumulator's
+// result is rounding-identical to v122. row_max/row_sum/exp2/l_row untouched.
+// -> n_bad=0, max_abs=0.0001 expected.
+//
+// WHY this should beat v129 (87.69) and v122 (91.68): vs v129 it removes the
+// loop-carried v_v1_prev (no prologue/drain imbalance, register-neutral); vs v122 it
+// inserts one independent WMMA between each accumulator's A and B to hide the RAW.
+//
+// VGPR: ~v122 (~205, 7 waves/SIMD). 4 live V fragments per group (same peak as v122's
+// inner loop already had 2 in flight + the rescale group). No LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast130(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v130_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v130_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v130(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast130(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v130_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v130_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast130(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast130(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            // PAIRWISE PV schedule within the CHUNK=2 group: load BOTH V halves for
+            // BOTH D-tiles up front (4 V fragments, all leading their use -> no
+            // load->WMMA bubble), then issue the WMMA stream  A0 A1 B0 B1.  Between
+            // A0 (writes o[dt0]) and B0 (reads o[dt0]) sits A1 -- one independent WMMA
+            // on a different accumulator -- so A0's matrix-pipe accumulate latency is
+            // hidden instead of stalling B0 back-to-back (v122 issued A;B adjacent).
+            // No loop-carried state across iterations (unlike v129's v_v1_prev), so no
+            // extra live range survives the loop step -> register-neutral vs v122.
+            // Per accumulator the two WMMAs remain in order A_dt then B_dt and
+            // independent accumulators never share an fp32 reduction -> bit-exact v122.
+            const int dt0 = c0;
+            const int dt1 = c0 + 1;
+            const bf16_t* a0_0 = VTp + (dt0 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a0_1 = VTp + (dt0 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            const bf16_t* a1_0 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8;
+            const bf16_t* a1_1 = VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+            bf16x8_t v_v0_a = *reinterpret_cast<const bf16x8_t*>(a0_0);
+            bf16x8_t v_v1_a = *reinterpret_cast<const bf16x8_t*>(a0_1);
+            bf16x8_t v_v0_b = *reinterpret_cast<const bf16x8_t*>(a1_0);
+            bf16x8_t v_v1_b = *reinterpret_cast<const bf16x8_t*>(a1_1);
+            v_o[dt0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0_a, v_p0, v_o[dt0]); // A0
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0_b, v_p0, v_o[dt1]); // A1
+            v_o[dt0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_a, v_p1, v_o[dt0]); // B0
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_b, v_p1, v_o[dt1]); // B1
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast130(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v131.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v131.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v131_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v131<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v131_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v131_template.hpp
@@ -1,0 +1,262 @@
+// v131 -- v122 champion (CHUNK=2 PV rescale) + DEPTH-2 A->B separation with
+//          PHASED V loads (the reviewer's CHUNK=3 "A0 A1 A2 B0 B1 B2" idea,
+//          but load-phased so peak live V fragments are LOWER than v130, not higher).
+//
+// PROVENANCE: v122 (91.68, this lane's champion) issues PV per D-tile as
+//   rescale(o[dt]); A_dt = wmma(v0,p0,o[dt]); B_dt = wmma(v1,p1,o[dt]);
+// The two WMMAs for the SAME accumulator are back-to-back -> B_dt RAW-stalls on
+// A_dt's matrix-pipe accumulate result with NO independent WMMA between them.
+//
+// Round 21's v130 tried CHUNK=2 "A0 A1 B0 B1": exactly ONE independent WMMA (A1)
+// between A0 and B0. The reviewer measured 90.03 (FAIL) and diagnosed TWO problems:
+//   (1) one intervening WMMA is NOT enough to cover gfx12's WMMA accumulate latency
+//       -- B0 still hits a RAW scoreboard stall;
+//   (2) v130 bunched FOUR V loads (4 bf16x8 = 16 VGPR) live at once before the WMMA
+//       group, raising transient VGPR + VMEM-scoreboard pressure in the hottest loop.
+// NEXT FOCUS from the reviewer: try "A0 A1 A2 B0 B1 B2" (CHUNK=3 -> TWO independent
+// WMMAs between each A and its B) but ONLY if VGPR/occupancy stays flat.
+//
+// THE CHANGE (PV phase only; QK^T/softmax/exp2/sum/pack/normalize byte-for-byte
+// v122): walk the D-tiles in CHUNK=3 groups (DK=8 -> groups {0,1,2},{3,4,5},{6,7}).
+// Within a group of size G we emit the WMMA stream  A0 A1 A2  B0 B1 B2, so between
+// A_k (writes o[dt_k]) and B_k (reads o[dt_k]) sit TWO independent WMMAs on other
+// accumulators (A_{k+1}, A_{k+2}) -- DOUBLE v130's separation, enough to cover the
+// accumulate latency the reviewer says one WMMA missed.
+//
+// CRUCIAL DIFFERENCE FROM v130 (attacks failure-cause #2): we do NOT preload all of
+// the group's V operands. We load only the G A-half V fragments (v0) up front, issue
+// the A WMMAs, THEN load the G B-half V fragments (v1) and issue the B WMMAs. So the
+// PEAK live V-fragment count is G=3 (12 VGPR) -- LESS than v130's 4 (16 VGPR) -- even
+// though the WMMA separation is deeper. The B-half loads issue during the A WMMAs'
+// matrix-pipe shadow, so their VMEM latency is hidden (the A operands already led the
+// A WMMAs). Net: deeper RAW separation AND lower peak register/VMEM pressure than v130.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): every accumulator v_o[dt] sees the
+// IDENTICAL ops in the IDENTICAL order as v122/v100: `*= rescale` (only if
+// need_rescale, same rescale) strictly before any WMMA on o[dt], then wmma(v0,p0,o[dt])
+// then wmma(v1,p1,o[dt]). The grouping only changes WHEN B_k is issued relative to
+// OTHER accumulators' WMMAs -- never the order of the two WMMAs touching the same
+// o[dt], and independent accumulators never share an fp32 reduction. Associativity-
+// neutral -> rounding-identical to v122/v100. row_max/row_sum/exp2/l_row untouched.
+// -> n_bad=0, max_abs=0.0001 expected.
+//
+// VGPR: <= v130 by construction (peak 3 live V fragments vs v130's 4). No loop-carried
+// V carry (unlike v129), no LDS, no barriers. Expect ~v122 occupancy (7 waves/SIMD).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast131(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v131_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v131_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v131(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast131(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v131_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v131_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast131(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast131(v_s1[j]);
+
+        // ---- PV: CHUNK=3 grouped online-rescale + DEPTH-2 A->B separation with
+        // PHASED V loads. Per group of up to CHUNK D-tiles:
+        //   1. rescale just this group's O fragments (short VALU region, <=3 hot);
+        //   2. load the group's A-half V fragments (v0) and issue all A WMMAs;
+        //   3. load the group's B-half V fragments (v1) and issue all B WMMAs.
+        // The emitted WMMA stream within a group is  A0 A1 A2  B0 B1 B2, so between
+        // A_k (writes o[dt_k]) and B_k (reads o[dt_k]) sit TWO independent WMMAs
+        // (A_{k+1}, A_{k+2}) -- double v130's 1-WMMA separation -> covers the gfx12
+        // accumulate latency. Peak live V fragments = CHUNK=3 (12 VGPR), LOWER than
+        // v130's 4 (16 VGPR): we never hold A and B operands simultaneously. The B
+        // loads issue in the A WMMAs' matrix-pipe shadow so their VMEM latency hides.
+        // Per accumulator: `*= rescale` then wmma(v0,p0) then wmma(v1,p1), same order
+        // as v122/v100; independent accumulators never share a reduction -> bit-exact.
+        constexpr int CHUNK = 3;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            const int G = (DK - c0 < CHUNK) ? (DK - c0) : CHUNK;
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    if (dc < G) {
+                        const int dt = c0 + dc;
+                        #pragma unroll
+                        for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                    }
+                }
+            }
+            // Phase A: load v0 halves, issue A WMMAs (A0 A1 A2).
+            bf16x8_t v_v0[CHUNK];
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                if (dc < G) {
+                    const int dt = c0 + dc;
+                    v_v0[dc] = *reinterpret_cast<const bf16x8_t*>(
+                        VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8);
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                if (dc < G) {
+                    const int dt = c0 + dc;
+                    v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0[dc], v_p0, v_o[dt]);
+                }
+            }
+            // Phase B: load v1 halves, issue B WMMAs (B0 B1 B2).
+            bf16x8_t v_v1[CHUNK];
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                if (dc < G) {
+                    const int dt = c0 + dc;
+                    v_v1[dc] = *reinterpret_cast<const bf16x8_t*>(
+                        VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                if (dc < G) {
+                    const int dt = c0 + dc;
+                    v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1[dc], v_p1, v_o[dt]);
+                }
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast131(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v132.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v132.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v132_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v132<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v132_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v132_template.hpp
@@ -1,0 +1,238 @@
+// v132 -- v122 (best, 91.68) + CHUNK=2 PV with PHASED B-half V prefetch.
+//
+// PROVENANCE / why this round: the round-22 reviewer closed three dead-ends and
+// gave one precise next lever. v122 (current best) issues each CHUNK=2 group as
+// `A0 B0 A1 B1` (per-dt single chain), so within a tile A_dt (writes o[dt]) is
+// immediately followed by B_dt (reads o[dt]) -> a back-to-back RAW scoreboard
+// stall on the matrix pipe. v130 fixed the RAW by reordering to `A0 A1 B0 B1`,
+// but to do so it loaded ALL FOUR V fragments (v0_a,v1_a,v0_b,v1_b) up front ->
+// peak 4 live V fragments (16 VGPR) AND the B operands had no real VMEM lead
+// time, so it regressed. v131 phased (all-A-then-all-B over CHUNK=3) but issued
+// the B-half loads only AFTER all A WMMAs, too late to hide their VMEM latency,
+// and also tied/regressed (87.09).
+//
+// THE CHANGE (reviewer's Lever 1, exactly): keep CHUNK=2 and v130's RAW-hiding
+// WMMA order `A0 A1 B0 B1`, but PHASE the loads so each B operand gets WMMA-shadow
+// lead time while peak live V fragments stays at 3 (12 VGPR), NOT 4:
+//
+//     load v0_a, v1_a          (tile dt0: both halves)
+//     load v0_b                (tile dt1: A-half only)
+//     A0 = wmma(v0_a, p0)      -> o[dt0]
+//     A1 = wmma(v0_b, p0)      -> o[dt1]        (independent acc; hides A0 latency)
+//     load v1_b                (tile dt1: B-half) -- issued in the A0/A1 shadow
+//     B0 = wmma(v1_a, p1)      -> o[dt0]        (v1_a loaded long ago: no bubble)
+//     B1 = wmma(v1_b, p1)      -> o[dt1]        (A1 sits between its load & use)
+//
+// Between A0 (writes o[dt0]) and B0 (reads o[dt0]) sits A1 -- one independent WMMA
+// -- so A0's accumulate latency is hidden (the win v122 lacks). v1_b's load is
+// emitted right after A1 issues, so its VMEM latency overlaps the A0+A1 matrix
+// work (the lead time v130 lacked). At no point are all four V fragments live:
+// v0_a is dead after A0, so the live set is {v1_a, v0_b, v1_b} = 3 (the cap the
+// reviewer asked to hold), one fewer than v130's 4.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the arithmetic touching each
+// accumulator v_o[dt] is UNCHANGED from v100/v122 -- for every dt it is still
+// exactly `v_o[dt] *= rescale` (only when need_rescale, same `rescale`), then the
+// same two WMMAs in the same order: wmma(v0,p0) then wmma(v1,p1). Only the
+// INTERLEAVING of two INDEPENDENT accumulators (o[dt0] vs o[dt1], which never
+// share an fp32 reduction) changes -> associativity-neutral, rounding-identical
+// to v122/v100. row_max/row_sum/exp2/l_row untouched -> n_bad=0, max_abs=0.0001.
+//
+// VGPR: ~v122 (~205, 7 waves/SIMD). 3 live V fragments (vs v130's 4); no loop-
+// carried V state, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast132(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v132_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v132_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v132(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast132(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v132_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v132_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast132(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast132(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale + RAW-hiding `A0 A1 B0 B1` WMMA
+        // order with PHASED B-half V prefetch (reviewer Lever 1). Per group:
+        //   1. rescale this group's 2 O fragments (short VALU region, <=2 hot);
+        //   2. load v0_a, v1_a (tile dt0 both halves) and v0_b (tile dt1 A-half);
+        //   3. A0 = wmma(v0_a,p0)->o[dt0];  A1 = wmma(v0_b,p0)->o[dt1];
+        //   4. load v1_b (tile dt1 B-half) -- issues in the A0/A1 WMMA shadow;
+        //   5. B0 = wmma(v1_a,p1)->o[dt0];  B1 = wmma(v1_b,p1)->o[dt1].
+        // A1 sits between A0 and B0 (hides A0's accumulate latency: the RAW fix
+        // v122 lacks). v1_b's load overlaps the A0+A1 matrix work (the lead time
+        // v130 lacked). v0_a dies after A0, so live V set = {v1_a,v0_b,v1_b} = 3
+        // (one fewer than v130's 4). Per accumulator the order is unchanged
+        // (`*=rescale`, wmma(v0,p0), wmma(v1,p1)); independent accumulators never
+        // share an fp32 reduction -> bit-exact vs v122/v100.
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            const int dt0 = c0;
+            const int dt1 = c0 + 1;
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt0][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt1][j] *= rescale;
+            }
+            // Phase 1: both halves of dt0 + A-half of dt1 (3 loads lead their use).
+            bf16x8_t v_v0_a = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt0 * W_K + col16) * vt_stride_d + n_base + row8);
+            bf16x8_t v_v1_a = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt0 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+            bf16x8_t v_v0_b = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8);
+            // A WMMAs (v0_a dead after A0 -> live V set drops back to 3).
+            v_o[dt0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0_a, v_p0, v_o[dt0]); // A0
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0_b, v_p0, v_o[dt1]); // A1
+            // Phase 2: dt1 B-half load issues in the A0/A1 matrix-pipe shadow.
+            bf16x8_t v_v1_b = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+            v_o[dt0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_a, v_p1, v_o[dt0]); // B0
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_b, v_p1, v_o[dt1]); // B1
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast132(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v133.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v133.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v133_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v133<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v133_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v133_template.hpp
@@ -1,0 +1,243 @@
+// v133 -- v122 (best, 91.68) + CHUNK=2 PV with the reviewer's exact `A0 load A1
+// B0 B1` schedule: v1_b's B-half load gets TWO WMMAs of VMEM lead, peak live 3.
+//
+// PROVENANCE / why this round: round-23 measured v133 at 90.9 TFLOPS (below the
+// 91.68 bar). The round-23 reviewer's root cause was precise: v133 issued the
+// CHUNK=2 group as `load(v0_a,v1_a,v0_b); A0; A1; load(v1_b); B0; B1`, so the
+// dt1 B-half load v1_b sits AFTER both A WMMAs and gets only ONE independent
+// WMMA (B0) of lead time before B1 consumes it -> a residual VMEM waitcnt bubble
+// on B1. The matrix work A0/A1 cannot hide a load that has not been issued yet.
+//
+// THE CHANGE (reviewer's mandated next lever, verbatim "A0, load v1_b, A1, B0,
+// B1"): move the v1_b load to immediately AFTER A0 (i.e. before A1). v1_b now has
+// TWO independent matrix instructions (A1 and B0) in front of its consumer B1 ->
+// real WMMA-shadow lead time, while peak live V fragments stays at 3 (NOT v130's
+// 4, which had v1_b live across all of A0/A1):
+//
+//     load v0_a, v1_a          (tile dt0: both halves)
+//     load v0_b                (tile dt1: A-half only)
+//     A0 = wmma(v0_a, p0)      -> o[dt0]
+//     load v1_b                (tile dt1: B-half) -- issued in the A1/B0 shadow
+//     A1 = wmma(v0_b, p0)      -> o[dt1]        (independent acc; hides A0 latency)
+//     B0 = wmma(v1_a, p1)      -> o[dt0]        (v1_a loaded long ago: no bubble)
+//     B1 = wmma(v1_b, p1)      -> o[dt1]        (A1+B0 lead v1_b's load: no bubble)
+//
+// Between A0 (writes o[dt0]) and B0 (reads o[dt0]) sits A1 -- one independent WMMA
+// -- so A0's accumulate latency is hidden (the win v122 lacks). v1_b's load is
+// emitted right after A0 issues, so its VMEM latency overlaps A1 + B0 (two matrix
+// instructions) -- one more than v133's single B0 of lead, closing the B1 bubble
+// the round-23 reviewer identified. Live V set: v0_a dies after A0, so at the v1_b
+// load the live set is {v1_a, v0_b, v1_b} = 3 (the cap the reviewer asked to hold),
+// one fewer than v130's 4.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the arithmetic touching each
+// accumulator v_o[dt] is UNCHANGED from v100/v122 -- for every dt it is still
+// exactly `v_o[dt] *= rescale` (only when need_rescale, same `rescale`), then the
+// same two WMMAs in the same order: wmma(v0,p0) then wmma(v1,p1). Only the
+// INTERLEAVING of two INDEPENDENT accumulators (o[dt0] vs o[dt1], which never
+// share an fp32 reduction) changes -> associativity-neutral, rounding-identical
+// to v122/v100. row_max/row_sum/exp2/l_row untouched -> n_bad=0, max_abs=0.0001.
+//
+// VGPR: ~v122 (~205, 7 waves/SIMD). 3 live V fragments (vs v130's 4); no loop-
+// carried V state, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast133(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v133_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v133_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v133(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast133(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v133_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v133_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast133(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast133(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale + RAW-hiding `A0 A1 B0 B1` WMMA
+        // order with the v1_b load PHASED between A0 and A1 (reviewer round-23
+        // lever, verbatim "A0, load v1_b, A1, B0, B1"). Per group:
+        //   1. rescale this group's 2 O fragments (short VALU region, <=2 hot);
+        //   2. load v0_a, v1_a (tile dt0 both halves) and v0_b (tile dt1 A-half);
+        //   3. A0 = wmma(v0_a,p0)->o[dt0];
+        //   4. load v1_b (tile dt1 B-half) -- issues in the A1/B0 WMMA shadow;
+        //   5. A1 = wmma(v0_b,p0)->o[dt1];  B0 = wmma(v1_a,p1)->o[dt0];
+        //   6. B1 = wmma(v1_b,p1)->o[dt1].
+        // A1 sits between A0 and B0 (hides A0's accumulate latency: the RAW fix
+        // v122 lacks). v1_b's load now has TWO independent WMMAs (A1, B0) of lead
+        // before its consumer B1 -- one more than v132's single B0 -- so the B1
+        // VMEM bubble the round-23 reviewer flagged closes. v0_a dies after A0, so
+        // at the v1_b load the live V set = {v1_a,v0_b,v1_b} = 3 (one fewer than
+        // v130's 4). Per accumulator the order is unchanged (`*=rescale`,
+        // wmma(v0,p0), wmma(v1,p1)); independent accumulators never share an fp32
+        // reduction -> bit-exact vs v122/v100.
+        constexpr int CHUNK = 2;
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            const int dt0 = c0;
+            const int dt1 = c0 + 1;
+            if (need_rescale) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt0][j] *= rescale;
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt1][j] *= rescale;
+            }
+            // Phase 1: both halves of dt0 + A-half of dt1 (3 loads lead their use).
+            bf16x8_t v_v0_a = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt0 * W_K + col16) * vt_stride_d + n_base + row8);
+            bf16x8_t v_v1_a = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt0 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+            bf16x8_t v_v0_b = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + row8);
+            // A0 first (v0_a dead after this -> live V set drops back to 3).
+            v_o[dt0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0_a, v_p0, v_o[dt0]); // A0
+            // Phase 2: dt1 B-half load issued NOW, ahead of A1 -- it gets A1 + B0
+            // (two matrix instructions) of VMEM lead before B1 consumes it.
+            bf16x8_t v_v1_b = *reinterpret_cast<const bf16x8_t*>(
+                VTp + (dt1 * W_K + col16) * vt_stride_d + n_base + 16 + row8);
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0_b, v_p0, v_o[dt1]); // A1
+            v_o[dt0] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_a, v_p1, v_o[dt0]); // B0
+            v_o[dt1] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1_b, v_p1, v_o[dt1]); // B1
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast133(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v134.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v134.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v134_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v134<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v134_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v134_template.hpp
@@ -1,0 +1,285 @@
+// v134 -- STRUCTURAL change (director mandate B): process 2 KV-tiles per WG
+// iteration with paired QK^T issued UP FRONT, to overlap tile-B's QK^T WMMAs
+// (matrix pipe) with tile-A's softmax (VALU/exp2/cross-lane pipe).
+//
+// PROVENANCE / why this round: the plateau intervention note says the
+// single-tile PV instruction-shuffle lever (v122..v133, deeper K rings, PV
+// groupings, rolling V prefetch) is EXHAUSTED -- ~20 rounds tied or regressed,
+// and the last few (v132 91.x, v133 91.2) all sit just under the 92.04 bar.
+// The note mandates a STRUCTURAL change: "process 2 KV-tiles per WG iteration
+// with a shared Q register file ... changes the loop STRUCTURE, not just
+// instruction order -- the only remaining path to the 93-95 ceiling."
+//
+// THE BOTTLENECK this targets: in the v100/v122 single-tile loop, each KV-tile
+// is QK^T (matrix) -> softmax (VALU + exp2 + 2 ds_bpermute cross-half folds, a
+// long serial transcendental/shuffle chain) -> PV (matrix). The softmax sits on
+// the critical path BETWEEN the two matrix phases with a hard RAW dependency, so
+// the matrix pipe idles through it. The PV-only reshuffles never addressed this
+// gap because they only move work that is already AFTER the softmax. With two
+// KV-tiles unrolled and BOTH QK^Ts emitted before either softmax, the compiler
+// is free to issue tile-B's QK^T WMMAs (which depend on nothing from tile A)
+// during tile-A's softmax VALU window -> the matrix pipe stays fed across the
+// softmax bubble. This is cross-pipe overlap at the LOOP-STRUCTURE granularity,
+// distinct from every prior round's PV micro-scheduling.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): the online-softmax state
+// (m_row, l_row) and the O accumulators are updated in EXACTLY the v100 order:
+// tile A's softmax (m_row/l_row update) precedes tile B's softmax, and tile A's
+// PV (v_o update) precedes tile B's PV. QK^T is a pure function of K and Q with
+// NO dependence on m_row/l_row/v_o, so hoisting tile B's QK^T ahead of tile A's
+// softmax changes only the issue order of independent matrix ops -- it is
+// arithmetically identical. Within each tile the reductions (row_max fmax chain,
+// row_sum add chain, ds_bpermute(lane^16) folds, rescale fold, exp2) are
+// byte-for-byte v100/v122. Independent O accumulators never share an fp32
+// reduction. -> n_bad=0, max_abs=0.0001 expected (same as v100/v122).
+//
+// LOOP BOUND: num_kv_tiles = N / BLOCK_N. The harness gate guarantees N%64==0,
+// and BLOCK_N=32, so num_kv_tiles = N/32 is always EVEN -> the pair loop never
+// has a remainder. (A scalar tail would be dead code under the gate; omitted to
+// keep one clean basic block. If N%64!=0 the host already rejects the run.)
+//
+// VGPR: holding two score-pair sets live (s0_A,s1_A,s0_B,s1_B = 4 fp32x8 = 32
+// fp32/lane) until their respective softmaxes adds ~16 VGPR over v122's single
+// pair (s_A consumed before s_B exists there). Estimated ~221 VGPR < 256 ceiling
+// -> occupancy stays 7 waves/SIMD (no spill, no LDS, no barriers). PV uses the
+// proven v122 single-chain per-accumulator order (lowest pressure, no PV-shuffle
+// risk) -- the novelty is purely the KV-unroll-by-2 with paired QK^T.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast134(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v134_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v134_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v134(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast134(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    // ---- Process TWO KV-tiles per iteration. num_kv_tiles is even (N%64==0).
+    for (int n_pair = 0; n_pair < num_kv_tiles; n_pair += 2) {
+        const int n_base_A = (n_pair)     * BLOCK_N;
+        const int n_base_B = (n_pair + 1) * BLOCK_N;
+
+        // ===== QK^T for BOTH tiles, issued UP FRONT (independent matrix work).
+        // Tile B's WMMAs have no dependence on tile A's softmax/PV, so the
+        // compiler can slot them into tile A's softmax VALU window.
+        fp32x8_t v_s0_A = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1_A = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s0_B = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1_B = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t kA0n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_A + col16) * stride_n + row8);
+        bf16x8_t kA1n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_A + 16 + col16) * stride_n + row8);
+        bf16x8_t kB0n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_B + col16) * stride_n + row8);
+        bf16x8_t kB1n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_B + 16 + col16) * stride_n + row8);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t kA0 = kA0n, kA1 = kA1n, kB0 = kB0n, kB1 = kB1n;
+            if (kt + 1 < DK) {
+                kA0n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_A + col16) * stride_n + (kt+1) * W_K + row8);
+                kA1n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_A + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+                kB0n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_B + col16) * stride_n + (kt+1) * W_K + row8);
+                kB1n = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base_B + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0_A = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(kA0, v_q[kt], v_s0_A);
+            v_s1_A = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(kA1, v_q[kt], v_s1_A);
+            v_s0_B = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(kB0, v_q[kt], v_s0_B);
+            v_s1_B = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(kB1, v_q[kt], v_s1_B);
+        }
+
+        // ===== TILE A: softmax (v100 order) -> PV (v122 single-chain order).
+        {
+            fp32_t row_max = v_s0_A[0];
+            #pragma unroll
+            for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0_A[j]);
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1_A[j]);
+            row_max = v134_cross_half_max(row_max);
+
+            const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+            fp32_t rescale = 1.0f;
+            const bool need_rescale = (new_m != m_row);
+            if (need_rescale) {
+                rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+                l_row *= rescale;
+            }
+            m_row = new_m;
+
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_s0_A[j] = __builtin_amdgcn_exp2f(v_s0_A[j] - new_m);
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_s1_A[j] = __builtin_amdgcn_exp2f(v_s1_A[j] - new_m);
+
+            fp32_t row_sum = v_s0_A[0];
+            #pragma unroll
+            for (int j = 1; j < 8; ++j) row_sum += v_s0_A[j];
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) row_sum += v_s1_A[j];
+            row_sum = v134_cross_half_sum(row_sum);
+            l_row += row_sum;
+
+            bf16x8_t v_p0, v_p1;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast134(v_s0_A[j]);
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast134(v_s1_A[j]);
+
+            if (need_rescale) {
+                #pragma unroll
+                for (int dt = 0; dt < DK; ++dt) {
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dt = 0; dt < DK; ++dt) {
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_A + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_A + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+
+        // ===== TILE B: softmax (v100 order, post-A state) -> PV. Bit-exact: B's
+        // m_row/l_row/v_o updates strictly follow A's, exactly as in v100.
+        {
+            fp32_t row_max = v_s0_B[0];
+            #pragma unroll
+            for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0_B[j]);
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1_B[j]);
+            row_max = v134_cross_half_max(row_max);
+
+            const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+            fp32_t rescale = 1.0f;
+            const bool need_rescale = (new_m != m_row);
+            if (need_rescale) {
+                rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+                l_row *= rescale;
+            }
+            m_row = new_m;
+
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_s0_B[j] = __builtin_amdgcn_exp2f(v_s0_B[j] - new_m);
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_s1_B[j] = __builtin_amdgcn_exp2f(v_s1_B[j] - new_m);
+
+            fp32_t row_sum = v_s0_B[0];
+            #pragma unroll
+            for (int j = 1; j < 8; ++j) row_sum += v_s0_B[j];
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) row_sum += v_s1_B[j];
+            row_sum = v134_cross_half_sum(row_sum);
+            l_row += row_sum;
+
+            bf16x8_t v_p0, v_p1;
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast134(v_s0_B[j]);
+            #pragma unroll
+            for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast134(v_s1_B[j]);
+
+            if (need_rescale) {
+                #pragma unroll
+                for (int dt = 0; dt < DK; ++dt) {
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dt = 0; dt < DK; ++dt) {
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_B + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base_B + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast134(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v135.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v135.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v135_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v135<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v135_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v135_template.hpp
@@ -1,0 +1,250 @@
+// v135 -- v122 champion body + s_setprio cross-wave issue-priority shaping around
+// the matrix (QK^T / PV) WMMA regions. ZERO VGPR cost, ZERO arithmetic change.
+//
+// PROVENANCE / why this lever, and why it is genuinely new for this lineage:
+// The champion is v122 (~91.2-92 TFLOPS): QK^T (K double-buffer) -> softmax ->
+// CHUNK=2 PV. It sits EXACTLY on the 7-wave / ~205-VGPR occupancy knee. The whole
+// failure history of this lane points at one conclusion:
+//   * PV/softmax MICRO-reshuffles (v123..v133): all tied or regressed (87-91).
+//     The single-tile instruction-order lever is exhausted.
+//   * Every CROSS-ITERATION ILP attempt cratered HARD on VGPR, not on logic:
+//     v119 (carry next-tile scores, +16 VGPR) = 75; v125 / v134 (4 live score
+//     pairs) = 67 / regress; v131 = 87; v121 (ballot rescale) = 72. Each added
+//     16-32 VGPR of carried state, dropped a wave, and lost more inter-wave
+//     overlap than the intra-wave ILP bought.
+// DIAGNOSIS: the softmax "matrix-pipe bubble" is ALREADY hidden the right way --
+// by INTER-WAVE overlap. With 7-8 wave32s resident per SIMD, while one wave runs
+// its softmax VALU/exp2/ds_bpermute chain, its siblings issue WMMA. That is why
+// any attempt to also hide it INTRA-wave (which costs registers) loses: it trades
+// away a resident wave -- the exact resource doing the hiding. So the remaining
+// lever is not MORE independent work; it is making the SIMD's round-robin issue
+// arbiter PREFER whichever wave is currently in its WMMA region over a wave that
+// is mid-softmax, so the matrix pipe is fed from the best-positioned wave every
+// cycle. That is precisely what s_setprio does -- and it has NEVER been tried in
+// this lineage (playbook lever #8: "s_delay_alu / scheduling hints via builtins").
+//
+// THE CHANGE (scheduling hints only; the entire v122 dataflow is byte-for-byte
+// identical -- same QK^T, same K double-buffer, same softmax, same exp2, same
+// pack, same CHUNK=2 PV, same normalize/store):
+//   * raise this wave's issue priority to 1 immediately BEFORE the QK^T WMMA loop
+//     and BEFORE the PV WMMA loop (the two matrix-pipe regions), and
+//   * drop it back to priority 0 right AFTER each, i.e. for the softmax VALU
+//     stretch and the loads.
+// On RDNA the SIMD issue arbiter breaks ties by wave priority; a wave in its
+// high-prio WMMA window wins the issue slot over a sibling that is in its low-prio
+// softmax window. Net effect: across the 7-8 resident waves, the matrix pipe is
+// kept busy by whichever wave is in its matrix phase, while softmax-phase waves
+// politely yield issue bandwidth they cannot use for matrix anyway. This is the
+// standard rocBLAS/CK GEMM mainloop trick (s_setprio around the MFMA/WMMA core)
+// applied to the FA2 mainloop for the first time here.
+//
+// s_setprio is a SCALAR instruction: it consumes NO VGPR and NO SGPR live range,
+// so v135 stays byte-for-byte at v122's register footprint (~205 VGPR, 7 waves) --
+// it does NOT touch the occupancy knee that killed every cross-iteration attempt.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): s_setprio changes only the
+// hardware issue PRIORITY of this wave; it cannot change any computed value, any
+// instruction, or any ordering of dependent ops within a wave (priority only
+// affects inter-wave arbitration, never intra-wave program order). Every fp32
+// reduction, exp2 arg, rescale fold, and WMMA accumulate is byte-for-byte v122 /
+// v100. -> n_bad=0, max_abs=0.0001 expected (identical to v122).
+//
+// VGPR: identical to v122 (~205, 7 waves/SIMD). No new buffers, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast135(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v135_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v135_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v135(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast135(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        // Raise issue priority for the QK^T matrix region so this wave wins the
+        // SIMD issue slot over any sibling currently stalled in its softmax VALU
+        // window. Scalar op: no VGPR/SGPR liveness, no arithmetic effect.
+        __builtin_amdgcn_s_setprio(1);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+        // Drop priority for the softmax VALU/exp2/cross-lane stretch: yield issue
+        // bandwidth (which this wave cannot use for the matrix pipe anyway) to a
+        // sibling wave that is in its high-prio QK^T / PV WMMA region.
+        __builtin_amdgcn_s_setprio(0);
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v135_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v135_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast135(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast135(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        // Raise issue priority for the PV matrix region (mirrors the QK^T region).
+        __builtin_amdgcn_s_setprio(1);
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+        // Drop priority before looping back into the next tile's K loads + softmax.
+        __builtin_amdgcn_s_setprio(0);
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast135(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v136.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v136.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v136_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v136<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v136_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v136_template.hpp
@@ -1,0 +1,244 @@
+// v136 -- v135 (s_setprio matrix-window shaping) with a TIGHTENED PV priority
+// window. ZERO VGPR cost, ZERO arithmetic change, bit-exact vs v135/v122/v100.
+//
+// PROVENANCE: v135 (92.42 TFLOPS, round-13 PASS) added s_setprio(1) around the
+// QK^T and PV matrix regions so a wave currently in its WMMA window wins the SIMD
+// issue arbiter over a sibling mid-softmax. The round-13 reviewer PASSED it but
+// flagged ONE imprecision (its explicit "NEXT"): v135's PV high-priority window
+// ALSO wraps the per-CHUNK `need_rescale` online-rescale VALU (up to CHUNK*8 = 16
+// fp32 mults/lane per group, 64/lane per KV tile). Those FMAs are NOT matrix work,
+// yet at the 7-wave occupancy knee a wave running them at high priority steals an
+// issue slot from a SIBLING wave that is actually mid-WMMA -- the exact wave the
+// hint is supposed to let win the matrix pipe. So v135's PV window is too wide and
+// partially fights itself.
+//
+// THE CHANGE (PV s_setprio placement ONLY; entire v135/v122 dataflow byte-for-byte
+// identical -- same QK^T + K double-buffer, same softmax/exp2/pack, same CHUNK=2
+// PV arithmetic, same normalize/store; QK^T priority window unchanged):
+//   * the per-CHUNK rescale FMAs now run at priority 0 (yield the issue slot, since
+//     they go on the VALU pipe regardless and cannot use the matrix pipe), and
+//   * priority is raised to 1 ONLY around each group's V loads + the two PV WMMAs,
+//     then dropped to 0 again before the next group's rescale.
+// Net effect: the PV matrix pipe is now fed ONLY by whichever wave is truly inside
+// a WMMA window, never by a wave doing rescale VALU. This sharpens exactly the
+// cross-wave arbitration win that gave v135 its +1.2 TFLOPS over v122.
+//
+// s_setprio is a SCALAR instruction: NO VGPR / NO SGPR live range. Moving / adding
+// the hint changes only hardware issue PRIORITY, so v136 stays byte-for-byte at
+// v122/v135's register footprint (~197-205 VGPR, 7 waves/SIMD) -- it does NOT touch
+// the occupancy knee that killed every cross-iteration ILP attempt (v119/v125/v134).
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): s_setprio cannot change any
+// computed value, any instruction, or the intra-wave ordering of dependent ops
+// (priority affects only inter-wave arbitration, never intra-wave program order).
+// Every fp32 reduction, exp2 arg, rescale fold, and WMMA accumulate is byte-for-byte
+// v135 / v122 / v100. -> n_bad=0, max_abs=0.0001 expected (identical to v135).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast136(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v136_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v136_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v136(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast136(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        // Raise issue priority for the QK^T matrix region so this wave wins the
+        // SIMD issue slot over any sibling currently stalled in its softmax VALU
+        // window. Scalar op: no VGPR/SGPR liveness, no arithmetic effect.
+        __builtin_amdgcn_s_setprio(1);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+        // Drop priority for the softmax VALU/exp2/cross-lane stretch: yield issue
+        // bandwidth (which this wave cannot use for the matrix pipe anyway) to a
+        // sibling wave that is in its high-prio QK^T / PV WMMA region.
+        __builtin_amdgcn_s_setprio(0);
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v136_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v136_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast136(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast136(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        // v136 TIGHTENING (round-13 reviewer NEXT): unlike v135, the per-CHUNK
+        // online-rescale FMAs run at priority 0, and priority is raised to 1 ONLY
+        // around each group's V-load + PV-WMMA matrix region (then dropped again).
+        // Rationale: v135's PV high-prio window also wrapped the need_rescale VALU
+        // (up to CHUNK*8 = 16 fp32 mults/lane per group, 64/lane per tile). At the
+        // 7-wave knee, a wave running rescale at high prio steals an issue slot from
+        // a SIBLING wave that is actually mid-WMMA -- the exact wave we want to win
+        // the matrix pipe. Keeping rescale at prio 0 lets the rescaling wave yield
+        // (its FMAs go on the VALU pipe regardless), so the matrix pipe is fed only
+        // by whoever is truly in a WMMA window. Pure scheduling: no VGPR, no
+        // arithmetic change -> byte-for-byte bit-exact vs v135/v122/v100.
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            // Raise priority only for this group's matrix region (V loads + WMMAs).
+            __builtin_amdgcn_s_setprio(1);
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+            // Drop priority for the next group's rescale VALU (yield to matrix-phase siblings).
+            __builtin_amdgcn_s_setprio(0);
+        }
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast136(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v137.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v137.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v137_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v137<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v137_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v137_template.hpp
@@ -1,0 +1,261 @@
+// v137 -- v135's SUSTAINED s_setprio matrix windows + batched pre-PV rescale.
+// Combines the round-13 champion (v135, 92.42) with the v43 batched-rescale lever,
+// implementing the round-13 reviewer's explicit NEXT. ZERO VGPR cost, bit-exact.
+//
+// PROVENANCE (the two relevant data points this round):
+//   * v135 (CHAMPION, 92.42 TFLOPS): the v122 body + s_setprio(1) raised ONCE before
+//     the QK^T WMMA loop and ONCE before the whole PV CHUNK loop, dropped to 0 for
+//     the softmax/load stretches. The win (+1.2 over v122) comes from a *sustained*
+//     high-priority PV WMMA window: a wave inside its WMMA region keeps winning the
+//     SIMD round-robin issue slot over siblings mid-softmax.
+//   * v136 (FAIL, 89.71, -2.71): tried to also exclude the per-CHUNK online-rescale
+//     VALU from the high-prio window by toggling s_setprio per CHUNK (4x raise/drop
+//     per KV tile). The round-13 reviewer's root cause: the rescale VALU is NOT the
+//     dominant interference; the win is the CONTINUOUS PV WMMA window, and per-CHUNK
+//     toggling SHATTERED it (added SALU churn + lost sustained WMMA arbitration).
+//     Reviewer NEXT (lever #2): "keep ONE s_setprio(1) across all PV WMMAs, but move
+//     the rescale block before the raise if structurally cheap."
+//
+// THE CHANGE (v135 -> v137), PV phase only; QK^T phase byte-for-byte v135:
+//   v135 PV:  rescale interleaved per-CHUNK INSIDE the single sustained window:
+//             setprio(1); { if(need) rescale 2 accs;  V-load; 2 WMMAs }x4; setprio(0)
+//   v137 PV:  HOIST the rescale into one batched pass over all 8 O accumulators
+//             BEFORE the raise, then ONE uninterrupted high-prio PV WMMA window:
+//             if(need){ rescale all 8 accs }   // prio 0, pure VALU
+//             setprio(1); { V-load; 2 WMMAs }x4;   setprio(0)
+// This is the structurally-clean way to satisfy the reviewer's NEXT: it keeps EXACTLY
+// the v135 sustained single-toggle PV window (one raise, one drop -- same SALU count
+// as v135, HALF of v136), and additionally removes the rescale FMAs from that window
+// without any per-group toggle. The batched pre-PV rescale is the v43 lever: a pure
+// VALU block the compiler can overlap with the QK^T issue shadow / first V-load
+// latency, while the matrix pipe in the PV window is fed ONLY by waves truly inside
+// a WMMA burst. Hypothesis: recovers v135's sustained-window win AND lets rescale
+// yield issue bandwidth, without the v136 churn that caused the regression.
+//
+// s_setprio is a SCALAR instruction: NO VGPR / NO SGPR live range. The rescale hoist
+// only reorders independent per-accumulator multiplies (see BIT-EXACTNESS); it adds
+// no buffers. v137 stays at v122/v135's footprint (~205 VGPR, 7 waves/SIMD) -- it does
+// NOT touch the occupancy knee that killed every cross-iteration ILP attempt.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): each accumulator v_o[dt] still
+// computes, IN ORDER, `*= rescale` (only when need_rescale) then wmma(v0,p0) then
+// wmma(v1,p1) -- byte-for-byte the v100/v122/v135 per-accumulator chain. The 8
+// accumulators are independent and never share a reduction, so hoisting all the
+// `*= rescale` multiplies ahead of all the WMMAs is associativity-neutral (it only
+// reorders ops across independent accumulators, never within one). s_setprio cannot
+// change any value or intra-wave program order. -> n_bad=0, max_abs=0.0001 expected.
+//
+// VGPR: identical to v122/v135 (~205, 7 waves/SIMD). No new buffers, no LDS, no barriers.
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast137(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v137_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v137_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v137(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast137(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        // Raise issue priority for the QK^T matrix region so this wave wins the
+        // SIMD issue slot over any sibling currently stalled in its softmax VALU
+        // window. Scalar op: no VGPR/SGPR liveness, no arithmetic effect.
+        __builtin_amdgcn_s_setprio(1);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+        // Drop priority for the softmax VALU/exp2/cross-lane stretch: yield issue
+        // bandwidth (which this wave cannot use for the matrix pipe anyway) to a
+        // sibling wave that is in its high-prio QK^T / PV WMMA region.
+        __builtin_amdgcn_s_setprio(0);
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v137_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v137_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast137(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast137(v_s1[j]);
+
+        // ---- PV: SINGLE-TOGGLE s_setprio window + batched pre-PV rescale.
+        //
+        // v135 (champion, 92.42) raised priority ONCE before the whole CHUNK loop and
+        // dropped it ONCE after -> one sustained high-prio PV WMMA window. v136 tried
+        // to also exclude the rescale VALU by toggling prio per CHUNK (4x/tile) and
+        // REGRESSED to 89.71: the round-13 reviewer's root cause was that the rescale
+        // VALU is NOT the dominant interference -- the win comes from a *continuous*
+        // high-priority PV WMMA window, and the per-CHUNK toggling shattered it.
+        //
+        // v137 = the reviewer's explicit NEXT (lever #2): keep ONE sustained
+        // s_setprio(1) over ALL PV WMMAs (no per-group toggle), and remove the rescale
+        // FMAs from that window the ONLY structurally-clean way -- hoist them into a
+        // single batched pass over all 8 O accumulators BEFORE the raise (the v43
+        // "batched pre-PV online rescale" lever). So the rescale runs at prio 0, the
+        // PV WMMA window is one uninterrupted high-prio block (as in v135), and there
+        // are exactly TWO scalar prio ops in the PV phase (same count as v135, half of
+        // v136). The pre-PV rescale block is also a pure VALU region whose FMAs the
+        // compiler can overlap with the QK^T issue shadow / V-load latency.
+        //
+        // BIT-EXACTNESS: each accumulator v_o[dt] still computes, in order,
+        // `*= rescale` (only when need_rescale) then wmma(v0,p0) then wmma(v1,p1) --
+        // byte-for-byte the v100/v122/v135 per-accumulator chain. Independent
+        // accumulators never share a reduction, so hoisting all the `*= rescale`
+        // multiplies ahead of all the WMMAs is associativity-neutral. -> n_bad=0.
+        constexpr int CHUNK = 2;
+        if (need_rescale) {
+            #pragma unroll
+            for (int dt = 0; dt < DK; ++dt) {
+                #pragma unroll
+                for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+            }
+        }
+        // One sustained high-priority window across ALL PV WMMAs (mirrors v135).
+        __builtin_amdgcn_s_setprio(1);
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+        // Drop priority before looping back into the next tile's K loads + softmax.
+        __builtin_amdgcn_s_setprio(0);
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast137(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v138.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v138.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v138_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v138<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v138_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v138_template.hpp
@@ -1,0 +1,258 @@
+// v138 -- v135 champion body + 3-LEVEL s_setprio (QK^T=2 > PV=1 > softmax/loads=0).
+// ZERO VGPR cost, ZERO arithmetic change, byte-for-byte v135/v122 dataflow.
+//
+// PROVENANCE / why this lever is genuinely new for this lineage:
+// The champion is v135 (92.42 TFLOPS, round-12 PASS) = v122 body + a BINARY
+// s_setprio scheme: priority 1 raised around BOTH WMMA regions (QK^T and PV) and
+// dropped to 0 for the softmax VALU / exp2 / cross-lane / load stretch. That single
+// step (matrix-phase waves outrank softmax-phase siblings at the SIMD issue
+// arbiter) was the whole +1.2 TFLOPS win. Two follow-ups that toggled priority
+// AGAINST the matrix burst both FAILED at 89.71:
+//   * v136 dropped to prio 0 for the per-CHUNK rescale VALU INSIDE the PV window
+//     (4 toggles/tile) -> shattered the continuous PV window.
+//   * v137 hoisted all rescale into one prio-0 island before the single PV window
+//     -> delayed wave entry into the PV matrix stream.
+// LESSON from both: do NOT lower priority anywhere adjacent to a WMMA burst. The
+// remaining open lever is the round-14 reviewer's #3: the QK^T and PV regions are
+// NOT symmetric, so giving them the SAME priority (v135) leaves arbitration on the
+// table when a QK-phase wave and a PV-phase wave contend for the same issue slot.
+//
+// THE ASYMMETRY (why QK^T deserves a HIGHER priority than PV):
+//   * QK^T runs only TWO independent WMMA chains (v_s0, v_s1), depth DK=8. Low ILP,
+//     and it is partly gated on the global K loads (even with the distance-1 K
+//     double-buffer the first dt's K must arrive). It is the more BUBBLE-PRONE
+//     matrix region -- the one that most needs to win the issue slot when it has
+//     work ready, because it cannot self-fill the matrix pipe from its own ILP.
+//   * PV runs EIGHT independent accumulator chains (v_o[0..7]), depth 2. High ILP;
+//     it keeps the matrix pipe busy from its own independent WMMAs and tolerates
+//     losing the occasional issue slot far better than QK^T does.
+// So when, across the 7-8 staggered resident waves, a wave in its QK^T window and a
+// sibling in its PV window both have a WMMA ready in the same cycle, we want the
+// bubble-prone QK^T wave to win; the high-ILP PV wave coasts on its own ILP and
+// loses nothing. v135 (both at prio 1) cannot express that preference.
+//
+// THE CHANGE (s_setprio immediates ONLY; v135/v122 dataflow byte-for-byte identical
+// -- same QK^T + distance-1 K double-buffer, same softmax/exp2/cross-lane/pack,
+// same CHUNK=2 PV with interleaved online-rescale, same normalize/store):
+//   QK^T WMMA region : s_setprio(2)   (was 1 in v135)  -- top priority
+//   PV   WMMA region : s_setprio(1)   (unchanged)      -- mid priority
+//   softmax / loads  : s_setprio(0)   (unchanged)      -- yields the issue slot
+// This is purely ADDITIVE to v135: both matrix regions still outrank softmax (so the
+// entire v135 yield benefit is preserved verbatim), and the new 2-vs-1 distinction
+// can only REFINE inter-matrix arbitration between a bubble-prone and a high-ILP
+// wave. s_setprio takes a 2-bit immediate (0..3); 2 is in range.
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): s_setprio is a SCALAR instruction
+// that changes only this wave's hardware ISSUE PRIORITY (inter-wave arbitration). It
+// consumes NO VGPR / NO SGPR live range and cannot change any computed value, any
+// instruction, or any intra-wave program order of dependent ops. Every fp32
+// reduction, exp2 arg, rescale fold, bf16 pack, and WMMA accumulate is byte-for-byte
+// v135 / v122 / v100. -> n_bad=0, max_abs=0.0001 expected (identical to v135).
+//
+// VGPR: identical to v135/v122 (~205, 7 waves/SIMD). No new buffers, no LDS, no
+// barriers, no occupancy change -- it does NOT touch the knee that killed every
+// cross-iteration ILP attempt (v119/v121/v125/v134).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast138(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v138_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v138_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v138(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast138(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        // v138: raise issue priority to the TOP level (2) for the QK^T matrix region.
+        // QK^T is the bubble-prone, low-ILP, K-load-gated matrix region; give it the
+        // highest claim on the SIMD issue slot so it wins over BOTH softmax-phase
+        // (prio 0) AND PV-phase (prio 1) sibling waves when it has a WMMA ready.
+        // Scalar op: no VGPR/SGPR liveness, no arithmetic effect.
+        __builtin_amdgcn_s_setprio(2);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+        // Drop priority to 0 for the softmax VALU/exp2/cross-lane stretch: yield issue
+        // bandwidth (which this wave cannot use for the matrix pipe anyway) to a
+        // sibling wave that is in its high-prio QK^T (2) or PV (1) WMMA region.
+        __builtin_amdgcn_s_setprio(0);
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v138_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v138_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast138(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast138(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        // v138: raise issue priority to the MID level (1) for the PV matrix region.
+        // PV has 8 independent accumulator chains (high ILP) so it self-fills the
+        // matrix pipe; it stays ABOVE softmax (prio 0) -- preserving v135's whole
+        // win -- but BELOW QK^T (prio 2) so a bubble-prone QK-phase sibling wins the
+        // contended slot while this high-ILP PV wave coasts on its own ILP.
+        __builtin_amdgcn_s_setprio(1);
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+        // Drop priority before looping back into the next tile's K loads + softmax.
+        __builtin_amdgcn_s_setprio(0);
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast138(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v139.cc
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v139.cc
@@ -1,0 +1,3 @@
+#include "attn_gfx1201_kernel_v139_template.hpp"
+
+template __global__ void opus_attn_gfx1201_kernel_v139<opus_attn_traits<128, 32, 128>>(opus_attn_kargs);

--- a/opus_attn_gfx1201/attn_gfx1201_kernel_v139_template.hpp
+++ b/opus_attn_gfx1201/attn_gfx1201_kernel_v139_template.hpp
@@ -1,0 +1,258 @@
+// v139 -- v138 champion body, push the asymmetric s_setprio gradient ONE step:
+// 3-LEVEL scheme becomes (QK^T=3 > PV=1 > softmax/loads=0). ZERO VGPR cost, ZERO
+// arithmetic change, byte-for-byte v138/v135/v122 dataflow.
+//
+// PROVENANCE / the measured positive gradient this extends:
+//   * v135 {QK=1, PV=1, softmax=0} = 92.42 TFLOPS (PASS). Binary scheme: both WMMA
+//     regions outrank softmax. The +1.2 over v122 came from matrix-phase waves
+//     winning the SIMD issue arbiter over siblings mid-softmax.
+//   * v138 {QK=2, PV=1, softmax=0} = 93.38 TFLOPS (PASS, current champion, +0.96).
+//     Splitting QK^T above PV refined inter-matrix arbitration: the bubble-prone,
+//     low-ILP QK^T wave wins the issue slot over a high-ILP PV sibling that coasts
+//     on its own independent accumulators. The v138 reviewer confirmed the model
+//     ("the gain is better scheduler arbitration among staggered resident waves")
+//     and the gradient 1->2 on QK^T is a clean, monotone +0.96.
+// v138's NEXT levers all kept QK at 2 and probed PV (PV=0, or a PV entry boost).
+// This round instead pushes the ONE knob that has actually produced gain twice in a
+// row -- the QK^T priority -- to the top of the s_setprio range.
+//
+// THE ASYMMETRY (why QK^T deserves the ABSOLUTE TOP priority):
+//   * QK^T runs only TWO independent WMMA chains (v_s0, v_s1), depth DK=8. Low ILP,
+//     and it is partly gated on the global K loads (even with the distance-1 K
+//     double-buffer the first dt's K must arrive). It is the more BUBBLE-PRONE
+//     matrix region -- the one that most needs to win the issue slot the instant it
+//     has work ready, because it cannot self-fill the matrix pipe from its own ILP.
+//   * PV runs EIGHT independent accumulator chains (v_o[0..7]), depth 2. High ILP;
+//     it keeps the matrix pipe busy from its own independent WMMAs and tolerates
+//     losing the occasional issue slot far better than QK^T does.
+// v138 already proved QK should outrank PV (2 vs 1). The remaining headroom: at
+// prio 2, QK^T can still TIE-then-lose to any non-FA sibling or scheduler state at
+// prio 2; lifting it to 3 (the max immediate) makes the bubble-prone QK^T wave the
+// unambiguous top of the SIMD arbiter whenever it has a ready WMMA, maximizing the
+// exact 2-vs-1 effect that bought v138 its +0.96. PV stays at 1 (still above
+// softmax=0, so v135's whole matrix-over-softmax yield is preserved verbatim), and
+// the QK/PV separation only WIDENS (3 vs 1) -- it cannot shrink the v138 win.
+//
+// THE CHANGE (one s_setprio immediate; v138/v135/v122 dataflow byte-for-byte
+// identical -- same QK^T + distance-1 K double-buffer, same softmax/exp2/cross-lane/
+// pack, same CHUNK=2 PV with interleaved online-rescale, same normalize/store):
+//   QK^T WMMA region : s_setprio(3)   (was 2 in v138)  -- ABSOLUTE top priority
+//   PV   WMMA region : s_setprio(1)   (unchanged)      -- mid priority
+//   softmax / loads  : s_setprio(0)   (unchanged)      -- yields the issue slot
+// s_setprio takes a 2-bit immediate (0..3); 3 is in range (the maximum).
+//
+// BIT-EXACTNESS (non-negotiable, max_abs<=0.005): s_setprio is a SCALAR instruction
+// that changes only this wave's hardware ISSUE PRIORITY (inter-wave arbitration). It
+// consumes NO VGPR / NO SGPR live range and cannot change any computed value, any
+// instruction, or any intra-wave program order of dependent ops. Every fp32
+// reduction, exp2 arg, rescale fold, bf16 pack, and WMMA accumulate is byte-for-byte
+// v138 / v135 / v122 / v100. -> n_bad=0, max_abs=0.0001 expected (identical to v138).
+//
+// VGPR: identical to v135/v122 (~205, 7 waves/SIMD). No new buffers, no LDS, no
+// barriers, no occupancy change -- it does NOT touch the knee that killed every
+// cross-iteration ILP attempt (v119/v121/v125/v134).
+#include <hip/hip_runtime.h>
+#include "attn_common.h"
+
+using bf16x8_t = bf16_t __attribute__((ext_vector_type(8)));
+using fp32x8_t = fp32_t __attribute__((ext_vector_type(8)));
+
+__device__ static inline bf16_t bf16_fast139(fp32_t f) {
+    unsigned int x = __builtin_bit_cast(unsigned int, f);
+    x += 0x7FFF + ((x >> 16) & 1);
+    return static_cast<bf16_t>(x >> 16);
+}
+
+__device__ static inline fp32_t v139_cross_half_max(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return __builtin_fmaxf(v, __builtin_bit_cast(fp32_t, other));
+}
+
+__device__ static inline fp32_t v139_cross_half_sum(fp32_t v) {
+    int x = __builtin_bit_cast(int, v);
+    int other = __builtin_amdgcn_ds_bpermute((threadIdx.x ^ 16) << 2, x);
+    return v + __builtin_bit_cast(fp32_t, other);
+}
+
+template<class T>
+__launch_bounds__(T::BLOCK_SIZE, 1)
+__global__ void opus_attn_gfx1201_kernel_v139(opus_attn_kargs k)
+{
+#if defined(__gfx1201__) || defined(__gfx1200__)
+    constexpr int BLOCK_M = T::BLOCK_M;
+    constexpr int BLOCK_N = T::BLOCK_N;
+    constexpr int W_K     = T::W_K;
+    constexpr int DK      = T::D_TILES_K;
+
+    const int tid     = static_cast<int>(threadIdx.x);
+    const int wave_id = tid / 32;
+    const int lane    = tid % 32;
+    const int col16   = lane % 16;
+    const int row_grp = lane / 16;
+    const int row8    = row_grp * 8;
+
+    const int q_tile_id = blockIdx.x;
+    const int h         = blockIdx.y;
+    const int b         = blockIdx.z;
+
+    const int stride_n = k.D;
+    const int stride_h = k.N * k.D;
+    const int stride_b = k.H * k.N * k.D;
+
+    const bf16_t* __restrict__ Qp = reinterpret_cast<const bf16_t*>(k.ptr_q) + b * stride_b + h * stride_h;
+    const bf16_t* __restrict__ Kp = reinterpret_cast<const bf16_t*>(k.ptr_k) + b * stride_b + h * stride_h;
+    bf16_t*       __restrict__ Op = reinterpret_cast<bf16_t*>(k.ptr_o) + b * stride_b + h * stride_h;
+
+    const int vt_stride_d = k.N;
+    const int vt_stride_h = k.D * k.N;
+    const int vt_stride_b = k.H * k.D * k.N;
+    const bf16_t* __restrict__ VTp = reinterpret_cast<const bf16_t*>(k.ptr_v) + b * vt_stride_b + h * vt_stride_h;
+
+    const int q_m_base = q_tile_id * BLOCK_M + wave_id * 16;
+    const bf16_t* q_row = Qp + (q_m_base + col16) * stride_n;
+    bf16x8_t v_q[DK];
+    constexpr fp32_t LOG2_E = 1.44269504088896340736f;
+    const fp32_t qscale = k.scale * LOG2_E;
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        v_q[kt] = *reinterpret_cast<const bf16x8_t*>(&q_row[kt * W_K + row8]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j)
+            v_q[kt][j] = bf16_fast139(bf16_to_f32(v_q[kt][j]) * qscale);
+    }
+
+    fp32x8_t v_o[DK];
+    #pragma unroll
+    for (int kt = 0; kt < DK; ++kt) {
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_o[kt][j] = 0.0f;
+    }
+    fp32_t m_row = -3.4e38f;
+    fp32_t l_row = 0.0f;
+
+    const int num_kv_tiles = k.N / BLOCK_N;
+
+    for (int n_tile = 0; n_tile < num_kv_tiles; ++n_tile) {
+        const int n_base = n_tile * BLOCK_N;
+
+        // ---- QK^T: BLOCK_N=32 -> two 16x16x16 WMMAs per D-tile.
+        // Software-pipelined K loads: preload D-tile 0, then issue dt+1's K loads
+        // before the WMMAs on dt so global VMEM overlaps the WMMA issue window.
+        fp32x8_t v_s0 = {0,0,0,0,0,0,0,0};
+        fp32x8_t v_s1 = {0,0,0,0,0,0,0,0};
+
+        bf16x8_t v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + row8);
+        bf16x8_t v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + row8);
+        // v139: raise issue priority to the ABSOLUTE TOP level (3) for the QK^T matrix
+        // region (v138 used 2; this widens the QK>PV separation to 3>1). QK^T is the
+        // bubble-prone, low-ILP, K-load-gated matrix region; give it the unambiguous
+        // highest claim on the SIMD issue slot so it wins over BOTH softmax-phase
+        // (prio 0) AND PV-phase (prio 1) sibling waves whenever it has a WMMA ready.
+        // Scalar op: no VGPR/SGPR liveness, no arithmetic effect. (immediate range 0..3)
+        __builtin_amdgcn_s_setprio(3);
+        #pragma unroll
+        for (int kt = 0; kt < DK; ++kt) {
+            bf16x8_t v_k0 = v_k0_next;
+            bf16x8_t v_k1 = v_k1_next;
+            if (kt + 1 < DK) {
+                v_k0_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + col16) * stride_n + (kt+1) * W_K + row8);
+                v_k1_next = *reinterpret_cast<const bf16x8_t*>(Kp + (n_base + 16 + col16) * stride_n + (kt+1) * W_K + row8);
+            }
+            v_s0 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k0, v_q[kt], v_s0);
+            v_s1 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_k1, v_q[kt], v_s1);
+        }
+        // Drop priority to 0 for the softmax VALU/exp2/cross-lane stretch: yield issue
+        // bandwidth (which this wave cannot use for the matrix pipe anyway) to a
+        // sibling wave that is in its high-prio QK^T (2) or PV (1) WMMA region.
+        __builtin_amdgcn_s_setprio(0);
+
+        // Softmax over 16 values (8 from s0, 8 from s1)
+        fp32_t row_max = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_max = __builtin_fmaxf(row_max, v_s1[j]);
+        row_max = v139_cross_half_max(row_max);
+
+        const fp32_t new_m = __builtin_fmaxf(m_row, row_max);
+        fp32_t rescale = 1.0f;
+        const bool need_rescale = (new_m != m_row);
+        if (need_rescale) {
+            rescale = __builtin_amdgcn_exp2f(m_row - new_m);
+            l_row *= rescale;
+        }
+        m_row = new_m;
+
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s0[j] = __builtin_amdgcn_exp2f(v_s0[j] - new_m);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_s1[j] = __builtin_amdgcn_exp2f(v_s1[j] - new_m);
+
+        fp32_t row_sum = v_s0[0];
+        #pragma unroll
+        for (int j = 1; j < 8; ++j) row_sum += v_s0[j];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) row_sum += v_s1[j];
+        row_sum = v139_cross_half_sum(row_sum);
+        l_row += row_sum;
+
+        bf16x8_t v_p0, v_p1;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p0[j] = bf16_fast139(v_s0[j]);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) v_p1[j] = bf16_fast139(v_s1[j]);
+
+        // ---- PV: CHUNK=2 grouped online-rescale interleaved with the PV WMMAs.
+        // Per group of CHUNK D-tiles: rescale just this group's O fragments (a short
+        // VALU region, only 2 fp32x8 accumulators hot), then issue the group's V
+        // loads and PV WMMAs. The next group's rescale FMAs overlap this group's
+        // WMMAs in the matrix-pipe shadow. Each accumulator v_o[dt]'s arithmetic is
+        // byte-for-byte v100: `*= rescale` (only if need_rescale), then wmma(v0,p0),
+        // then wmma(v1,p1). Independent accumulators never share a reduction, so the
+        // regrouping is associativity-neutral -> bit-exact vs v100.
+        constexpr int CHUNK = 2;
+        // v139: raise issue priority to the MID level (1) for the PV matrix region.
+        // PV has 8 independent accumulator chains (high ILP) so it self-fills the
+        // matrix pipe; it stays ABOVE softmax (prio 0) -- preserving v135's whole
+        // win -- but BELOW QK^T (prio 2) so a bubble-prone QK-phase sibling wins the
+        // contended slot while this high-ILP PV wave coasts on its own ILP.
+        __builtin_amdgcn_s_setprio(1);
+        #pragma unroll
+        for (int c0 = 0; c0 < DK; c0 += CHUNK) {
+            if (need_rescale) {
+                #pragma unroll
+                for (int dc = 0; dc < CHUNK; ++dc) {
+                    const int dt = c0 + dc;
+                    #pragma unroll
+                    for (int j = 0; j < 8; ++j) v_o[dt][j] *= rescale;
+                }
+            }
+            #pragma unroll
+            for (int dc = 0; dc < CHUNK; ++dc) {
+                const int dt = c0 + dc;
+                const bf16_t* vt_addr0 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + row8;
+                const bf16_t* vt_addr1 = VTp + (dt * W_K + col16) * vt_stride_d + n_base + 16 + row8;
+                bf16x8_t v_v0 = *reinterpret_cast<const bf16x8_t*>(vt_addr0);
+                bf16x8_t v_v1 = *reinterpret_cast<const bf16x8_t*>(vt_addr1);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v0, v_p0, v_o[dt]);
+                v_o[dt] = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(v_v1, v_p1, v_o[dt]);
+            }
+        }
+        // Drop priority before looping back into the next tile's K loads + softmax.
+        __builtin_amdgcn_s_setprio(0);
+    }
+
+    const fp32_t inv = (l_row > 0.0f) ? (1.0f / l_row) : 0.0f;
+    bf16_t* o_row = Op + (q_m_base + col16) * stride_n;
+    #pragma unroll
+    for (int dt = 0; dt < DK; ++dt) {
+        bf16x8_t o_pack;
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) o_pack[j] = bf16_fast139(v_o[dt][j] * inv);
+        *reinterpret_cast<bf16x8_t*>(&o_row[dt * W_K + row8]) = o_pack;
+    }
+#else
+    (void)k;
+#endif
+}


### PR DESCRIPTION
## opus_attn_gfx1201: HIP flash-attention forward beyond PR #24 (lane_A)

A new pure-HIP Flash-Attention-2 forward kernel version (`v139`) for **gfx1201
(RX 9070 XT, RDNA4, wave32 WMMA)** that **beats the best HIP-buildable version
(v39 ≈ 86.7 TFLOPS, measured best-of-3 on this hardware)** from #24 while
staying bit-exact in bf16.

Produced by an autonomous RLCR loop (Claude implements + Codex independently reviews),
benchmarked in a reproducible ROCm 7.2.3 docker container on this hardware. Ablation
lane: `lane_A` (ROCmKernelWiki ON).

### Benchmark (RX 9070 XT, ROCm 7.2.3, bf16, fp32 acc, D=128, best-of-3)
| shape | metric | v39 (PR#24 best HIP) | v139 (ours) |
|---|---|---:|---:|
| b=4 h=32 n=4096 | TFLOPS (verify off) | 86.7 | **92.8** |

Correctness: `n_bad(>0.05)=0`, max_abs=0.0001 at b=1 h=32 n=2048 (bit-exact within bf16).
Methodology learned from [mit-han-lab/kernel-design-agents] + [PolyArch/humanize] (RLCR).
Reference: builds on #24's version-by-version methodology; #24 credited as the basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
