### PR TITLE
Add AMD/HIP software-PDL benchmark (MI355X + RDNA4)

### DIFF
--- a/pdl_bench/amd/.gitignore
+++ b/pdl_bench/amd/.gitignore
@@ -1,0 +1,9 @@
+# build artifacts
+pdl_bench_amd.exe
+trace_test
+*.o
+*.exe
+# rocprofv3 trace output
+tr_*/
+# python
+__pycache__/

--- a/pdl_bench/amd/Makefile
+++ b/pdl_bench/amd/Makefile
@@ -1,0 +1,18 @@
+HIPCC      ?= hipcc
+HIP_ARCH   ?= --offload-arch=gfx950
+
+CXXFLAGS   := -std=c++17 -O3
+HIPCCFLAGS := $(HIP_ARCH) $(CXXFLAGS)
+
+TARGET     := pdl_bench_amd.exe
+SRC        := pdl_bench.hip
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(HIPCC) $(HIPCCFLAGS) $< -o $@
+
+clean:
+	rm -f $(TARGET)

--- a/pdl_bench/amd/README.md
+++ b/pdl_bench/amd/README.md
@@ -1,0 +1,202 @@
+# pdl_bench / amd -- Software PDL emulation on AMD MI355X (gfx950)
+
+A HIP port of the [PDL microbenchmark](../README.md) for AMD CDNA GPUs, which
+have **no Programmatic Dependent Launch hardware**. We emulate the PDL
+producer/consumer handshake in software with a **single global semaphore**.
+
+## The idea
+
+NVIDIA PDL lets a producer kernel signal completion
+(`cudaTriggerProgrammaticLaunchCompletion()`) so a back-to-back consumer can
+race ahead through independent work and only block
+(`cudaGridDependencySynchronize()`) right before it touches the producer's
+output.
+
+We rebuild that edge with a `uint32` device buffer, `pdl_semaphore`:
+
+| Step | CUDA PDL | This emulation (HIP) |
+|------|----------|----------------------|
+| init | (hardware) | `pdl_semaphore = producer_grid_size` |
+| producer signal | `cudaTriggerProgrammaticLaunchCompletion()` | `__syncthreads()`; lead thread `__hip_atomic_fetch_add(sem, -1, __ATOMIC_RELEASE, AGENT)` |
+| consumer wait | `cudaGridDependencySynchronize()` | `__syncthreads()`; lead thread spins on `__hip_atomic_load(sem, RELAXED, AGENT)` until `0`, then acquire fence; `__syncthreads()` |
+
+The lead thread is the workgroup leader (`threadIdx.x == 0`), so the semaphore
+is decremented exactly once per producer workgroup and reaches `0` only after
+**every** producer workgroup has published its writes.
+
+Memory model: the producer's per-thread writes are made workgroup-visible by
+`__syncthreads()` and published agent-wide by the **release** decrement; the
+consumer's lead thread pairs that with an **acquire** fence after the spin, and
+the trailing `__syncthreads()` propagates that ordering to the rest of the
+workgroup before it reads the producer's data.
+
+## Same stream: `hipExtAnyOrderLaunch` (works on RDNA, NOT on CDNA/gfx950)
+
+The natural same-stream approach is `hipExtLaunchKernel(..., hipExtAnyOrderLaunch)`,
+which asks the runtime to relax the in-order stream guarantee so the consumer can
+start before the producer finishes — the closest analogue to NVIDIA PDL. The
+benchmark includes this path (`run_anyorder_pair`).
+
+**It is a no-op on MI355X.** `hip/hip_ext.h` states the flag is *"not supported on
+AMD GFX9xx boards,"* and gfx950 is in that family. Measured directly with two
+*independent* long kernels on one stream (grid=256, lots of spare CUs):
+
+```
+normal in-order (1 stream): 40.74 ms
+anyOrder flag   (1 stream): 40.76 ms  (1.00x  -> still serialized)
+2 streams (control)       : 20.69 ms  (1.97x  -> overlap is real & detectable)
+```
+
+So on gfx950 the consumer does **not** begin before the producer completes on the
+same stream, regardless of the flag.
+
+### Why: it's hardware, not the API
+
+The flag is **honored** by the runtime — `clr/rocclr/device/rocm/rocvirtual.cpp`
+unconditionally clears the AQL barrier bit
+(`aqlHeader &= ~(1 << HSA_PACKET_HEADER_BARRIER)`) when `getAnyOrderLaunchFlag()`
+is set; there is no gfx9 software gate. Clearing the bit removes the *software*
+ordering, but the **CDNA (gfx9xx) command processor still serializes dispatches
+within one hardware queue** — it won't launch the next grid from a queue until
+the in-flight grid retires. So clearing the barrier bit is necessary but not
+sufficient on CDNA. RDNA's dispatch front-end *can* hold multiple grids in flight
+per queue, which is why the flag works there (see below). Concurrency on CDNA
+must come from multiple HW queues = multiple streams.
+
+### RDNA4 (gfx1201) -- the flag DOES work
+
+Same benchmark + probe on an RX 9070 XT (gfx1201, 32 WGPs). Here
+`hipExtAnyOrderLaunch` gives genuine same-stream overlap, and because it clears
+the barrier bit on *every* dispatch the whole launch pipeline overlaps (not just
+a pair), so it beats two streams at small grids:
+
+```
+two independent kernels, same stream, sweep:
+grid=8     normal 22.95 ms | anyOrder  2.43 ms (9.44x) | 2-stream 11.85 ms (1.94x)
+grid=16    normal 22.96 ms | anyOrder  4.74 ms (4.85x) | 2-stream 11.88 ms (1.93x)
+grid=32    normal 22.94 ms | anyOrder  9.26 ms (2.48x) | 2-stream 11.92 ms (1.92x)
+grid=64    normal 23.04 ms | anyOrder 18.30 ms (1.26x) | 2-stream 18.79 ms (1.23x)
+grid=256   normal 80.42 ms | anyOrder 72.81 ms (1.10x) | 2-stream 72.93 ms (1.10x)
+
+pdl_bench (producer/consumer + semaphore), N=8192 grid=32:
+Baseline                    : 0.363 ms
+Same stream + anyOrder + sem: 0.191 ms (1.90x)   <- works on gfx1201
+Software PDL (2 streams)    : 0.203 ms (1.78x)
+```
+
+The win shrinks toward 1x as the grid saturates the WGPs (no spare capacity to
+overlap into). The binary now prints an architecture-aware note: `[anyOrder
+active...]` on RDNA, `[anyOrder no-op on gfx9xx...]` on CDNA.
+
+**Takeaway:** for a PDL-style *same-stream* producer/consumer overlap,
+`hipExtAnyOrderLaunch` + the semaphore is the right tool on **RDNA (gfx10/11/12)**;
+on **CDNA (gfx9xx)** it cannot work and you must fall back to the two-stream path.
+
+## Profiler confirmation (rocprofv3)
+
+Wall-clock speedup could in principle be a measurement artifact, so the overlap
+is double-confirmed with a kernel-dispatch timeline. `trace_test.hip` launches a
+fixed number of kernels on **one stream** (mode 0 = normal, 1 = anyOrder);
+`parse_trace.py` reads the rocprofv3 CSV and checks whether the dispatch
+intervals overlap *on the same hardware queue*.
+
+```bash
+hipcc --offload-arch=gfx1201 -O3 -std=c++17 trace_test.hip -o trace_test
+rocprofv3 --kernel-trace -f csv -d tr_normal -o k -- ./trace_test 0 4 8 50000
+rocprofv3 --kernel-trace -f csv -d tr_any    -o k -- ./trace_test 1 4 8 50000
+python3 parse_trace.py            # reads tr_normal/ and tr_any/
+```
+
+All 4 dispatches land on the **same queue (Queue 1, Stream 1)** in every run, so
+this is genuinely same-stream behaviour — not multiple HW queues:
+
+```
+gfx1201 (RDNA4)            start_us   end_us
+  normal   disp 1..4        0 / 687 / 1359 / 2033   -> back-to-back   concurrency 0.98x
+  anyOrder disp 1..4        0 / 2.6 / 4.8 / 7.0      -> all overlap    concurrency 3.94x
+
+gfx950 (CDNA4)
+  normal   disp 1..4        0 / 1186 / 2371 / 3556   -> back-to-back   concurrency 1.00x
+  anyOrder disp 1..4        0 / 1187 / 2371 / 3556   -> back-to-back   concurrency 1.00x  (no effect)
+```
+
+`concurrency = sum(kernel durations) / wall_span`. On gfx1201 the four kernels
+start within 7 us of each other and run simultaneously (3.94x ~= 4 concurrent);
+on gfx950 each starts exactly when the previous ends, with or without the flag.
+This matches the clr source analysis: the runtime clears the AQL barrier bit on
+both, but only RDNA's dispatch front-end acts on it.
+
+## Why two streams (CDNA fallback)
+
+Since same-stream overlap is unavailable, we run the **producer on stream A and
+the consumer on stream B**; the semaphore re-introduces the data dependency that
+the separate streams dropped. Per-pair events ping-pong so the single shared
+semaphore is never reused while a pair is still in flight.
+
+## Build & run
+
+```bash
+make
+./pdl_bench_amd.exe [N] [tail_iters] [head_iters] [iterations]
+```
+
+Requires ROCm with `hipcc` and `--offload-arch=gfx950` (MI350/MI355). Tested
+with ROCm 7.1.1 on MI355X.
+
+## Results (MI355X, 256 CUs, ROCm 7.1.1)
+
+| Config | grid (blk) | baseline avg | same-stream anyOrder | software-PDL (2 stream) | speedup |
+|--------|-----------:|-------------:|---------------------:|------------------------:|:-------:|
+| `65536 16384 16384` (heavy)  | 256  | 0.669 ms | 0.675 ms (0.99x) | 0.406 ms | **1.65x** |
+| `65536 1024 1024`  (light)   | 256  | 0.045 ms | ~baseline        | 0.053 ms | 0.86x |
+| `262144 16384 16384` (heavy) | 1024 | 0.787 ms | ~baseline        | 0.946 ms | 0.83x |
+| `1048576 16384 16384`        | 4096 | 2.361 ms | ~baseline        | *skipped* | — |
+
+The `anyOrder` column tracks baseline (~1.0x) everywhere — the flag never
+overlaps on gfx950. Only the two-stream path produces real overlap.
+
+Correctness (`consumer sees producer writes`) **PASS** in every runnable case.
+
+## When it helps, when it doesn't
+
+The software handshake is **not free** and only the *heavy + small-grid* case
+wins. Three regimes:
+
+1. **Sweet spot (grid << GPU capacity, heavy kernels) -> ~1.6x.** Each kernel
+   underutilizes the 256 CUs, so running producer and consumer concurrently
+   packs the idle CUs. The semaphore overhead is tiny next to 16k-FMA kernels.
+2. **Light kernels -> slower (0.86x).** The reset kernel + two events +
+   cross-stream waits + spin cost more than the few microseconds of overlap.
+3. **GPU-saturating grids -> slower (0.83x).** When the two grids already fill
+   the machine there is no spare capacity to overlap into; concurrency just adds
+   the handshake cost. This is a genuine gap vs. hardware PDL, which still
+   overlaps the producer tail with the consumer head even for full grids.
+
+## Hard limit: co-residency (deadlock guard)
+
+Because a resident consumer workgroup **spins** (holding its CU), producer and
+consumer workgroups must be able to live on the GPU **at the same time**. If
+they can't, resident spinning consumers starve the unscheduled producers and the
+kernel **deadlocks** — there is no hardware scheduler to break it, unlike real
+PDL.
+
+The benchmark queries `hipOccupancyMaxActiveBlocksPerMultiprocessor` and
+**skips** the PDL run (rather than hanging) when
+
+```
+2 * grid  >  CUs * min(producer_blk_per_CU, consumer_blk_per_CU)
+```
+
+On MI355X both kernels hit 8 blocks/CU -> budget 2048 blocks, so the largest
+safe grid is ~1024 blocks/kernel. The `N=1048576` row above (4096 blocks) is
+correctly skipped.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `pdl_bench.hip` | HIP source: reset/producer/consumer kernels, semaphore handshake, occupancy guard, correctness check, timing |
+| `trace_test.hip` | Minimal N-kernels-on-one-stream launcher (normal vs anyOrder) for profiler confirmation |
+| `parse_trace.py` | Parses rocprofv3 `--kernel-trace` CSV and reports per-queue dispatch overlap / concurrency factor |
+| `Makefile` | Build rules (`--offload-arch=gfx950`; override `HIP_ARCH` for gfx1201) |
+| `README.md` | This file |

--- a/pdl_bench/amd/parse_trace.py
+++ b/pdl_bench/amd/parse_trace.py
@@ -1,0 +1,25 @@
+import csv, glob
+for run in ["tr_normal", "tr_any"]:
+    f = glob.glob(run + "/*kernel_trace.csv")[0]
+    rows = []
+    with open(f) as fh:
+        for r in csv.DictReader(fh):
+            rows.append((r["Queue_Id"], r["Stream_Id"], int(r["Dispatch_Id"]),
+                         int(r["Start_Timestamp"]), int(r["End_Timestamp"])))
+    rows.sort(key=lambda x: x[3])
+    base = rows[0][3]
+    print("=" * 64)
+    print("###", run)
+    print("%-7s%-8s%-6s%11s%11s%10s" % ("Queue", "Stream", "Disp", "start_us", "end_us", "dur_us"))
+    for q, st, ds, s, e in rows:
+        print("%-7s%-8s%-6s%11.2f%11.2f%10.2f" % (q, st, ds, (s-base)/1e3, (e-base)/1e3, (e-s)/1e3))
+    # count overlapping consecutive intervals (sorted by start)
+    ov = sum(1 for i in range(1, len(rows)) if rows[i][3] < rows[i-1][4])
+    qs = sorted(set(r[0] for r in rows)); sts = sorted(set(r[1] for r in rows))
+    # wall span vs sum of durations -> concurrency factor
+    span = (max(e for *_, e in rows) - min(s for *_, s, _ in [(r[0],r[1],r[2],r[3],r[4]) for r in rows])) / 1e3
+    sumdur = sum((e - s) for *_, s, e in [(r[0],r[1],r[2],r[3],r[4]) for r in rows]) / 1e3
+    print("-> kernels=%d queues=%s streams=%s overlapping_pairs=%d  %s" %
+          (len(rows), qs, sts, ov, "=> CONCURRENT on same queue" if ov > 0 else "=> serialized"))
+    print("   wall_span=%.2f us  sum_of_durations=%.2f us  concurrency=%.2fx" %
+          (span, sumdur, sumdur/span if span else 0))

--- a/pdl_bench/amd/pdl_bench.hip
+++ b/pdl_bench/amd/pdl_bench.hip
@@ -1,0 +1,299 @@
+// pdl_bench (AMD / MI355X, gfx950) -- software emulation of NVIDIA's
+// Programmatic Dependent Launch (PDL) using a single global semaphore.
+//
+// AMD GPUs have no PDL hardware. We reproduce the *effect* (overlap the
+// producer's post-trigger "tail" with the consumer's pre-sync "head") with:
+//
+//   * a single uint32 device buffer  `pdl_semaphore`
+//   * initialised to the producer grid size (number of workgroups)
+//   * each producer workgroup decrements it once, at the point where CUDA
+//     would call cudaTriggerProgrammaticLaunchCompletion()
+//   * each consumer workgroup spin-waits for it to reach 0, at the point
+//     where CUDA would call cudaGridDependencySynchronize()
+//
+// Because same-stream kernels serialize on AMD, the overlap only materialises
+// when producer and consumer run on *separate streams*. The semaphore then
+// replaces the hardware grid-dependency edge: it lets the consumer race ahead
+// through its independent head compute, but blocks the dependent epilogue until
+// every producer workgroup has published its writes.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_ext.h>   // hipExtLaunchKernel + hipExtAnyOrderLaunch
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <chrono>
+
+constexpr int BLOCK_SIZE = 256;
+
+// Prevent the compiler from optimizing away the timing loops.
+__device__ __forceinline__ float dummy_compute(float x, int iters) {
+    float acc = x;
+    #pragma unroll 1
+    for (int i = 0; i < iters; ++i) {
+        acc = fmaf(acc, 1.0001f, float(i & 0xFF));
+    }
+    return acc;
+}
+
+// Set the semaphore to `v` (one thread). Atomic store keeps it ordered w.r.t.
+// the producer's atomic decrement / consumer's atomic load.
+__global__ void reset_sem_kernel(unsigned int* sem, unsigned int v) {
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        __hip_atomic_store(sem, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    }
+}
+
+// Producer: small write, "trigger" (decrement semaphore), then long tail compute.
+// USE_PDL=false reproduces a plain producer with no semaphore traffic (baseline).
+template <bool USE_PDL>
+__global__ void producer_kernel(float* __restrict__ out, int N, int tail_iters,
+                                unsigned int* __restrict__ sem) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < N) {
+        out[idx] = 1.0f;
+    }
+
+    if (USE_PDL) {
+        // === equivalent of cudaTriggerProgrammaticLaunchCompletion() ===
+        // Make every thread's write above visible within the workgroup, then
+        // the lead thread publishes it agent-wide via a release decrement.
+        __syncthreads();
+        if (threadIdx.x == 0) {  // one lead thread per workgroup (threadIdx.x % BLOCK_SIZE == 0)
+            __hip_atomic_fetch_add(sem, -1, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
+        }
+    }
+
+    if (tail_iters > 0) {
+        float acc = dummy_compute(__int_as_float(idx), tail_iters);
+        if (acc == 1.23456789e30f && idx < N) {
+            out[idx] = acc;
+        }
+    }
+}
+
+// Consumer: long head compute (independent), grid-dependency sync, then small
+// dependent work. USE_PDL=false skips the semaphore wait (baseline).
+template <bool USE_PDL>
+__global__ void consumer_kernel(const float* __restrict__ in,
+                                float* __restrict__ out,
+                                int N, int head_iters,
+                                unsigned int* __restrict__ sem) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    float acc = 0.0f;
+    if (head_iters > 0) {
+        acc = dummy_compute(__int_as_float(idx ^ 0x1A2B3C4D), head_iters);
+    }
+
+    if (USE_PDL) {
+        // === equivalent of cudaGridDependencySynchronize() ===
+        // Barrier so the whole workgroup has finished its head compute, then the
+        // lead thread spins until all producer workgroups have signalled.
+        __syncthreads();
+        if (threadIdx.x == 0) {
+            while (__hip_atomic_load(sem, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT) != 0u) {
+                /* spin */
+            }
+            // Acquire so the producers' writes (released via the decrement) are
+            // visible to this thread before we read `in` below. The spin itself
+            // uses relaxed loads to keep the busy-wait cheap.
+            __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "agent");
+        }
+        // Propagate the lead thread's acquire to the rest of the workgroup so no
+        // non-lead thread reads `in` before the dependency is satisfied.
+        __syncthreads();
+    }
+
+    if (idx < N) {
+        out[idx] = in[idx] + acc;
+    }
+}
+
+static void checkHip(hipError_t err, const char* file, int line) {
+    if (err != hipSuccess) {
+        fprintf(stderr, "HIP error at %s:%d: %s\n", file, line, hipGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+}
+#define CHECK(x) checkHip(x, __FILE__, __LINE__)
+
+using Clock = std::chrono::high_resolution_clock;
+static double ms_since(Clock::time_point t0) {
+    return std::chrono::duration<double, std::milli>(Clock::now() - t0).count();
+}
+
+int main(int argc, char** argv) {
+    int N = 1 << 16;
+    int tail_iters = 16384;
+    int head_iters = 16384;
+    int warmup = 10;
+    int iters = 100;
+
+    if (argc > 1) N = atoi(argv[1]);
+    if (argc > 2) tail_iters = atoi(argv[2]);
+    if (argc > 3) head_iters = atoi(argv[3]);
+    if (argc > 4) iters = atoi(argv[4]);
+
+    int dev = 0;
+    CHECK(hipSetDevice(dev));
+    hipDeviceProp_t prop;
+    CHECK(hipGetDeviceProperties(&prop, dev));
+    printf("Device: %s (%s), %d CUs/WGPs\n", prop.name, prop.gcnArchName, prop.multiProcessorCount);
+    // hipExtAnyOrderLaunch clears the AQL barrier bit; this gives real same-stream
+    // overlap on gfx10/11/12 (RDNA) but is a no-op on gfx9xx (CDNA/Vega), whose
+    // command processor serializes same-queue dispatches in hardware regardless.
+    bool anyorder_hw = (strncmp(prop.gcnArchName, "gfx9", 4) != 0);
+    const char* anyorder_note = anyorder_hw ? "[anyOrder active: same-stream overlap supported]"
+                                            : "[anyOrder no-op on gfx9xx: same-queue serializes in HW]";
+
+    int grid = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3 block(BLOCK_SIZE);
+    dim3 gdim(grid);
+
+    // Co-residency guard. The software handshake spins, so a consumer workgroup
+    // that becomes resident holds its CU until the semaphore hits 0. If producer
+    // and consumer workgroups cannot all be co-resident, resident spinning
+    // consumers starve the not-yet-scheduled producers -> deadlock (unlike
+    // hardware PDL, which the scheduler resolves). Require both grids to fit.
+    int occP = 0, occC = 0;
+    CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&occP, producer_kernel<true>, BLOCK_SIZE, 0));
+    CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&occC, consumer_kernel<true>, BLOCK_SIZE, 0));
+    int co_resident_budget = prop.multiProcessorCount * (occP < occC ? occP : occC);
+    bool pdl_safe = (2 * grid) <= co_resident_budget;
+    printf("Occupancy: producer %d blk/CU, consumer %d blk/CU -> co-resident budget %d blocks; need %d (2x%d)%s\n",
+           occP, occC, co_resident_budget, 2 * grid, grid, pdl_safe ? "" : "  [UNSAFE]");
+
+    size_t bytes = static_cast<size_t>(N) * sizeof(float);
+    float *d_producer_out, *d_consumer_out;
+    unsigned int* d_sem;
+    CHECK(hipMalloc(&d_producer_out, bytes));
+    CHECK(hipMalloc(&d_consumer_out, bytes));
+    CHECK(hipMalloc(&d_sem, sizeof(unsigned int)));
+
+    // Stream A drives producers (+ semaphore reset); stream B drives consumers.
+    hipStream_t streamA, streamB;
+    CHECK(hipStreamCreate(&streamA));
+    CHECK(hipStreamCreate(&streamB));
+
+    // Ping-pong events: evReset gates the consumer behind this pair's reset;
+    // evPair gates the next pair's reset behind this pair's consumer (so the
+    // single shared semaphore is never reused across an in-flight pair).
+    hipEvent_t evReset, evPair;
+    CHECK(hipEventCreate(&evReset));
+    CHECK(hipEventCreate(&evPair));
+
+    // -------- Baseline: producer then consumer, same stream, no semaphore -----
+    auto run_baseline = [&]() {
+        producer_kernel<false><<<gdim, block, 0, streamA>>>(d_producer_out, N, tail_iters, d_sem);
+        consumer_kernel<false><<<gdim, block, 0, streamA>>>(d_producer_out, d_consumer_out, N, head_iters, d_sem);
+    };
+
+    // -------- Software PDL: two streams + semaphore --------------------------
+    auto run_pdl_pair = [&](int i) {
+        if (i > 0) CHECK(hipStreamWaitEvent(streamA, evPair, 0));   // wait prev consumer
+        reset_sem_kernel<<<1, 1, 0, streamA>>>(d_sem, (unsigned int)grid);
+        CHECK(hipEventRecord(evReset, streamA));
+        CHECK(hipStreamWaitEvent(streamB, evReset, 0));             // consumer waits for reset
+        producer_kernel<true><<<gdim, block, 0, streamA>>>(d_producer_out, N, tail_iters, d_sem);
+        consumer_kernel<true><<<gdim, block, 0, streamB>>>(d_producer_out, d_consumer_out, N, head_iters, d_sem);
+        CHECK(hipEventRecord(evPair, streamB));
+    };
+
+    // -------- Same-stream "any-order" launch (the PDL-on-same-stream idea) ----
+    // hipExtLaunchKernel(..., hipExtAnyOrderLaunch) asks the runtime to relax the
+    // in-order stream guarantee so the consumer may start before the producer
+    // finishes -- the closest analogue to NVIDIA PDL (same stream, overlap). The
+    // semaphore still provides the data dependency. NOTE: this flag is documented
+    // as unsupported on GFX9xx and is a no-op on gfx950 (kernels still serialize),
+    // so this path measures ~baseline here. It is kept to demonstrate that.
+    auto run_anyorder_pair = [&]() {
+        reset_sem_kernel<<<1, 1, 0, streamA>>>(d_sem, (unsigned int)grid);
+        float* p_out = d_producer_out; float* c_out = d_consumer_out;
+        const float* c_in = d_producer_out; unsigned int* sem = d_sem;
+        int n = N, ti = tail_iters, hi = head_iters;
+        void* pargs[] = {&p_out, &n, &ti, &sem};
+        void* cargs[] = {&c_in, &c_out, &n, &hi, &sem};
+        CHECK(hipExtLaunchKernel((void*)producer_kernel<true>, gdim, block, pargs, 0,
+                                 streamA, nullptr, nullptr, hipExtAnyOrderLaunch));
+        CHECK(hipExtLaunchKernel((void*)consumer_kernel<true>, gdim, block, cargs, 0,
+                                 streamA, nullptr, nullptr, hipExtAnyOrderLaunch));
+    };
+
+    // --- Warmup ---
+    for (int i = 0; i < warmup; ++i) run_baseline();
+    CHECK(hipStreamSynchronize(streamA));
+    for (int i = 0; i < warmup; ++i) run_anyorder_pair();
+    CHECK(hipStreamSynchronize(streamA));
+    if (pdl_safe) {
+        for (int i = 0; i < warmup; ++i) run_pdl_pair(i);
+        CHECK(hipDeviceSynchronize());
+    }
+
+    // --- Baseline timing (wall clock, end-to-end) ---
+    auto t0 = Clock::now();
+    for (int i = 0; i < iters; ++i) run_baseline();
+    CHECK(hipStreamSynchronize(streamA));
+    double baseline_ms = ms_since(t0);
+
+    // --- Same-stream any-order timing ---
+    t0 = Clock::now();
+    for (int i = 0; i < iters; ++i) run_anyorder_pair();
+    CHECK(hipStreamSynchronize(streamA));
+    double anyorder_ms = ms_since(t0);
+
+    // --- Software-PDL timing ---
+    double pdl_ms = 0;
+    if (pdl_safe) {
+        t0 = Clock::now();
+        for (int i = 0; i < iters; ++i) run_pdl_pair(i);
+        CHECK(hipDeviceSynchronize());
+        pdl_ms = ms_since(t0);
+    }
+
+    // --- Correctness: does the consumer observe the producer's writes? -------
+    // Producer writes 1.0f; consumer (PDL) copies in[idx] -> out[idx] with no
+    // head compute. With a correct semaphore handshake every element must be 1.
+    if (pdl_safe) {
+        CHECK(hipMemset(d_consumer_out, 0, bytes));
+        reset_sem_kernel<<<1, 1, 0, streamA>>>(d_sem, (unsigned int)grid);
+        CHECK(hipEventRecord(evReset, streamA));
+        CHECK(hipStreamWaitEvent(streamB, evReset, 0));
+        producer_kernel<true><<<gdim, block, 0, streamA>>>(d_producer_out, N, /*tail*/4096, d_sem);
+        consumer_kernel<true><<<gdim, block, 0, streamB>>>(d_producer_out, d_consumer_out, N, /*head*/0, d_sem);
+        CHECK(hipDeviceSynchronize());
+
+        float* h = (float*)malloc(bytes);
+        CHECK(hipMemcpy(h, d_consumer_out, bytes, hipMemcpyDeviceToHost));
+        int bad = 0;
+        for (int k = 0; k < N; ++k) if (h[k] != 1.0f) { ++bad; }
+        printf("Correctness (consumer sees producer writes): %s (%d/%d mismatched)\n",
+               bad == 0 ? "PASS" : "FAIL", bad, N);
+        free(h);
+    }
+
+    // --- Results ---
+    printf("\n=== Software-PDL Microbenchmark (single global semaphore) ===\n");
+    printf("N=%d, grid=%d blocks x %d, tail_iters=%d, head_iters=%d, iterations=%d\n",
+           N, grid, BLOCK_SIZE, tail_iters, head_iters, iters);
+    printf("Baseline (1 stream, sequential)     : %.3f ms total, %.3f ms avg\n",
+           baseline_ms, baseline_ms / iters);
+    printf("Same stream + anyOrder + sem        : %.3f ms total, %.3f ms avg (%.2fx)  %s\n",
+           anyorder_ms, anyorder_ms / iters, baseline_ms / anyorder_ms, anyorder_note);
+    if (pdl_safe) {
+        printf("Software PDL (2 streams + sem)       : %.3f ms total, %.3f ms avg (%.2fx)\n",
+               pdl_ms, pdl_ms / iters, baseline_ms / pdl_ms);
+    } else {
+        printf("Software PDL (2 streams + sem)       : SKIPPED -- grids cannot be co-resident "
+               "(deadlock risk). Reduce N or BLOCK_SIZE so 2*grid <= %d.\n", co_resident_budget);
+    }
+
+    CHECK(hipFree(d_producer_out));
+    CHECK(hipFree(d_consumer_out));
+    CHECK(hipFree(d_sem));
+    CHECK(hipEventDestroy(evReset));
+    CHECK(hipEventDestroy(evPair));
+    CHECK(hipStreamDestroy(streamA));
+    CHECK(hipStreamDestroy(streamB));
+    return 0;
+}

--- a/pdl_bench/amd/trace_test.hip
+++ b/pdl_bench/amd/trace_test.hip
@@ -1,0 +1,38 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_ext.h>
+#include <cstdio>
+#include <cstdlib>
+
+__global__ void busy(float* out, int n, int iters, int tag) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    float acc = (float)idx + tag;
+    #pragma unroll 1
+    for (int i = 0; i < iters; ++i) acc = fmaf(acc, 1.0001f, float(i & 0xFF));
+    if (acc == 1.2345e30f && idx < n) out[idx] = acc;
+}
+
+#define CK(x) do{ hipError_t e=(x); if(e!=hipSuccess){printf("ERR %s\n",hipGetErrorString(e)); return 1;} }while(0)
+
+int main(int argc, char** argv){
+    int mode = argc>1 ? atoi(argv[1]) : 1;   // 0=normal in-order, 1=anyOrder
+    int nk   = argc>2 ? atoi(argv[2]) : 4;   // number of kernels on the stream
+    int grid = argc>3 ? atoi(argv[3]) : 8;   // small grid -> spare occupancy
+    int iters= argc>4 ? atoi(argv[4]) : 50000;
+    const int BS=256; int N=grid*BS;
+    float* d; CK(hipMalloc(&d, N*sizeof(float)));
+    hipStream_t s; CK(hipStreamCreate(&s));
+    dim3 g(grid), b(BS);
+
+    for (int k=0;k<nk;k++){
+        if (mode==0) {
+            busy<<<g,b,0,s>>>(d,N,iters,k);
+        } else {
+            void* a[]={&d,&N,&iters,&k};
+            CK(hipExtLaunchKernel((void*)busy,g,b,a,0,s,nullptr,nullptr,hipExtAnyOrderLaunch));
+        }
+    }
+    CK(hipStreamSynchronize(s));
+    printf("mode=%s nk=%d grid=%d iters=%d : done\n", mode?"anyOrder":"normal", nk, grid, iters);
+    hipFree(d); hipStreamDestroy(s);
+    return 0;
+}


### PR DESCRIPTION
## Summary

Ports the [`pdl_bench`](../README.md) Programmatic Dependent Launch microbenchmark to AMD GPUs (new `pdl_bench/amd/` subdirectory). AMD has no PDL hardware, so the producer/consumer handshake is emulated with a **single global `uint32` semaphore**:

- Initialised to the producer grid size.
- Producer lead thread (one per workgroup) decrements it with a **release** atomic at the point CUDA would call `cudaTriggerProgrammaticLaunchCompletion()`.
- Consumer lead thread spin-waits for zero (then an **acquire** fence) where CUDA would call `cudaGridDependencySynchronize()`.

## What's included

- **`pdl_bench.hip`** — reset/producer/consumer kernels, the semaphore handshake, an occupancy-based **co-residency guard** (skips the run instead of deadlocking when producer+consumer grids can't co-reside), a correctness check, and three timed modes: baseline, same-stream `hipExtAnyOrderLaunch`, and two-stream.
- **`trace_test.hip` + `parse_trace.py`** — rocprofv3 `--kernel-trace` confirmation that dispatches actually overlap on a single hardware queue.
- **`README.md`** — full analysis, results, and reproduction steps.
- **`Makefile`** (`--offload-arch=gfx950`, override `HIP_ARCH` for gfx1201) and `.gitignore`.

## Key finding: `hipExtAnyOrderLaunch` is architecture-dependent

The flag clears the AQL packet barrier bit in the runtime on **all** GPUs (verified in the clr source), but only **RDNA (gfx10/11/12)** acts on it; **CDNA/gfx9xx** serializes same-queue dispatches in hardware regardless.

| | gfx950 (CDNA4 / MI355X) | gfx1201 (RDNA4) |
|---|---|---|
| same-stream `anyOrder` | no overlap (1.00x) | **1.90x** (pdl_bench), up to **9.4x** (independent kernels) |
| two-stream + semaphore | **1.65x** | 1.78x |
| rocprofv3 concurrency (4 kernels, 1 queue) | 1.00x | **3.94x** |

**Guidance:** use same-stream `anyOrder` + semaphore on RDNA; fall back to two streams on CDNA.

## Testing

- Built and run on MI355X (gfx950, ROCm 7.1.1) and RX 9070 XT (gfx1201, ROCm 7.2).
- Correctness check (`consumer sees producer writes`) PASS on both.
- Overlap independently confirmed via rocprofv3 kernel-dispatch timeline.