### PR TITLE
opus_cast: migrate fp4 to one-element packed-array convention

### DIFF
--- a/opus_cast/opus_cast.cpp
+++ b/opus_cast/opus_cast.cpp
@@ -35,8 +35,11 @@ template<typename DType, typename SType, int VEC_SIZE>
 __global__ void cast_kernel_with_f4(DType* __restrict__ dst,  const SType* __restrict__ src,  
                     size_t N) {
     using opus::operator""_I;
-    using D_VEC_T = opus::array<DType, VEC_SIZE / opus::num_packs_v<DType>>;
-    using S_VEC_T = opus::array<SType, VEC_SIZE / opus::num_packs_v<SType>>;
+    // opus::array now takes the logical element count directly and bit-packs sub-byte types
+    // (fp4_t is one 4-bit value; cutlass float_e2m1_t convention). VEC_SIZE values -> array<T, VEC_SIZE>
+    // occupying ceil(VEC_SIZE*bits/8) bytes; no /num_packs_v (that was the old fp4x2-per-element model).
+    using D_VEC_T = opus::array<DType, VEC_SIZE>;
+    using S_VEC_T = opus::array<SType, VEC_SIZE>;
 
     // opus::bool_constant<std::is_same_v<opus::get_value_t<S_VEC_T>, opus::fp4_t>>{}.zzz();
     // opus::tuple_array<opus::fp4_t, 4>{}.uuu();


### PR DESCRIPTION
## Summary

Updates `opus_cast` for the new opus sub-byte **pack** convention, where `fp4_t` (and `int4_t`/`uint4_t`) is **one logical element** (cutlass `float_e2m1_t` style) and `opus::array`/`opus::vector` bit-pack it: `array<fp4_t, N>` holds `N` values in `ceil(N*bits/8)` bytes.

`cast_kernel_with_f4` used the old idiom:
```cpp
using D_VEC_T = opus::array<DType, VEC_SIZE / opus::num_packs_v<DType>>;
```
Under the new convention that **double-counts** (the container already packs), so `array<fp4_t, VEC_SIZE/2>` holds only `VEC_SIZE/2` values and the `__builtin_bit_cast` sizes no longer match (e.g. `error: ... 8 vs 4 bytes`).

Fix — drop the `/num_packs_v` factor; `opus::array` takes the logical value count directly:
```cpp
using D_VEC_T = opus::array<DType, VEC_SIZE>;
using S_VEC_T = opus::array<SType, VEC_SIZE>;
```

## Verification (gfx950 / MI355)
- Builds clean (0 errors) against the updated `opus.hpp`.
- fp4 fwd/bwd round-trips are correct — nearest e2m1 with saturation at ±6 — for `VEC_SIZE` 16/8/4/2.
- The non-fp4 paths (`cast_kernel`) are unchanged.

Only `opus_cast` used the `/num_packs_v` idiom; a repo-wide scan found no other source needing this migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)