### PR TITLE
Add LICENSE (All Rights Reserved, permission required)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2026 carlushuang. All Rights Reserved.
+
+Public availability of this repository grants NO rights to the work
+except as stated below.
+
+You may download, build, and run this work for evaluation, research,
+and benchmarking purposes.
+
+However, without the prior express written permission of the copyright
+holder, no part of this work may be copied, modified, distributed,
+incorporated into any other project, product, or service, or used
+commercially, in whole or in part.
+
+The only other rights granted are those required by the GitHub Terms of
+Service to view and fork this repository within GitHub; any fork must
+retain this notice and grants no additional rights.
+
+For permission requests, contact the copyright holder via
+https://github.com/carlushuang/gcnasm.
+
+THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY ARISING FROM THE WORK OR ITS USE.


### PR DESCRIPTION
## Summary

Add a **LICENSE** file to the repository establishing an **All Rights Reserved / permission-required** model:

- The public availability of this repo grants **no** rights to use, copy, modify, distribute, or incorporate any part of the code into other projects without **prior express written permission** of the copyright holder.
- Explicitly also covers commercial use and use for ML/AI training.
- Only rights granted are those strictly required by the GitHub Terms of Service (view and fork within GitHub).
- Standard as is warranty disclaimer included.

This makes the terms explicit rather than relying on default copyright (which is already all rights reserved for unlicensed repos), so there is no ambiguity for anyone viewing the code.
